### PR TITLE
Use enum value list macros to simplify switch statements

### DIFF
--- a/lib/ome/files/PixelProperties.cpp
+++ b/lib/ome/files/PixelProperties.cpp
@@ -74,7 +74,7 @@ namespace ome
       return size;
     }
 
-#undef BYTE_PT_CASE;
+#undef BYTE_PT_CASE
 
 #define BIT_PT_CASE(maR, maProperty, maType)                                  \
         case PixelType::maType:                                               \
@@ -94,7 +94,7 @@ namespace ome
       return size;
     }
 
-#undef BIT_PT_CASE;
+#undef BIT_PT_CASE
 
 #define SIGBIT_PT_CASE(maR, maProperty, maType)                                                   \
         case PixelType::maType:                                                                   \
@@ -114,7 +114,7 @@ namespace ome
       return size;
     }
 
-#undef SIGBIT_PT_CASE;
+#undef SIGBIT_PT_CASE
 
 #define SIGN_PT_CASE(maR, maProperty, maType)                                 \
         case PixelType::maType:                                               \
@@ -134,7 +134,7 @@ namespace ome
       return is_signed;
     }
 
-#undef SIGN_PT_CASE;
+#undef SIGN_PT_CASE
 
 #define INTEGER_PT_CASE(maR, maProperty, maType)                            \
         case PixelType::maType:                                             \
@@ -154,7 +154,7 @@ namespace ome
       return is_integer;
     }
 
-#undef INTEGER_PT_CASE;
+#undef INTEGER_PT_CASE
 
     bool
     isFloatingPoint(::ome::xml::model::enums::PixelType pixeltype)
@@ -180,7 +180,7 @@ namespace ome
       return is_complex;
     }
 
-#undef COMPLEX_PT_CASE;
+#undef COMPLEX_PT_CASE
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop

--- a/lib/ome/files/PixelProperties.cpp
+++ b/lib/ome/files/PixelProperties.cpp
@@ -39,6 +39,10 @@
 
 #include <stdexcept>
 
+#include <boost/preprocessor.hpp>
+
+using ::ome::xml::model::enums::PixelType;
+
 namespace ome
 {
   namespace files
@@ -52,6 +56,11 @@ namespace ome
 #  pragma GCC diagnostic ignored "-Wswitch-default"
 #endif
 
+#define BYTE_PT_CASE(maR, maProperty, maType)                                           \
+        case PixelType::maType:                                                         \
+          maProperty = PixelProperties< PixelType::maType>::pixel_byte_size();          \
+          break;
+
     pixel_size_type
     bytesPerPixel(::ome::xml::model::enums::PixelType pixeltype)
     {
@@ -59,43 +68,18 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::pixel_byte_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::pixel_byte_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::pixel_byte_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::pixel_byte_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::pixel_byte_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::pixel_byte_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::pixel_byte_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::pixel_byte_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::pixel_byte_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::pixel_byte_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::pixel_byte_size();
-          break;
+          BOOST_PP_SEQ_FOR_EACH(BYTE_PT_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return size;
     }
+
+#undef BYTE_PT_CASE;
+
+#define BIT_PT_CASE(maR, maProperty, maType)                                  \
+        case PixelType::maType:                                               \
+          maProperty = PixelProperties< PixelType::maType>::pixel_bit_size(); \
+          break;
 
     pixel_size_type
     bitsPerPixel(::ome::xml::model::enums::PixelType pixeltype)
@@ -104,43 +88,18 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::pixel_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::pixel_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::pixel_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::pixel_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::pixel_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::pixel_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::pixel_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::pixel_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::pixel_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::pixel_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::pixel_bit_size();
-          break;
+          BOOST_PP_SEQ_FOR_EACH(BIT_PT_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return size;
     }
+
+#undef BIT_PT_CASE;
+
+#define SIGBIT_PT_CASE(maR, maProperty, maType)                                                   \
+        case PixelType::maType:                                                                   \
+          maProperty = PixelProperties< PixelType::maType>::pixel_significant_bit_size();         \
+          break;
 
     pixel_size_type
     significantBitsPerPixel(::ome::xml::model::enums::PixelType pixeltype)
@@ -149,43 +108,18 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::pixel_significant_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::pixel_significant_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::pixel_significant_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::pixel_significant_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::pixel_significant_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::pixel_significant_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::pixel_significant_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::pixel_significant_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::pixel_significant_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::pixel_significant_bit_size();
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          size = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::pixel_significant_bit_size();
-          break;
+          BOOST_PP_SEQ_FOR_EACH(SIGBIT_PT_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return size;
     }
+
+#undef SIGBIT_PT_CASE;
+
+#define SIGN_PT_CASE(maR, maProperty, maType)                                 \
+        case PixelType::maType:                                               \
+          maProperty = PixelProperties< PixelType::maType>::is_signed;        \
+          break;
 
     bool
     isSigned(::ome::xml::model::enums::PixelType pixeltype)
@@ -194,43 +128,18 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::is_signed;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::is_signed;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::is_signed;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::is_signed;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::is_signed;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::is_signed;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::is_signed;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::is_signed;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::is_signed;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::is_signed;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          is_signed = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::is_signed;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(SIGN_PT_CASE, is_signed, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return is_signed;
     }
+
+#undef SIGN_PT_CASE;
+
+#define INTEGER_PT_CASE(maR, maProperty, maType)                            \
+        case PixelType::maType:                                             \
+          maProperty = PixelProperties< PixelType::maType>::is_integer;     \
+          break;
 
     bool
     isInteger(::ome::xml::model::enums::PixelType pixeltype)
@@ -239,49 +148,24 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::is_integer;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::is_integer;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::is_integer;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::is_integer;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::is_integer;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::is_integer;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::is_integer;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::is_integer;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::is_integer;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::is_integer;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          is_integer = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::is_integer;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(INTEGER_PT_CASE, is_integer, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return is_integer;
     }
+
+#undef INTEGER_PT_CASE;
 
     bool
     isFloatingPoint(::ome::xml::model::enums::PixelType pixeltype)
     {
       return !isInteger(pixeltype);
     }
+
+#define COMPLEX_PT_CASE(maR, maProperty, maType)                            \
+        case PixelType::maType:                                             \
+          maProperty = PixelProperties< PixelType::maType>::is_complex;     \
+          break;
 
     bool
     isComplex(::ome::xml::model::enums::PixelType pixeltype)
@@ -290,43 +174,13 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::is_complex;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::is_complex;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::is_complex;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::is_complex;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::is_complex;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::is_complex;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::is_complex;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::is_complex;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::is_complex;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::is_complex;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          is_complex = PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::is_complex;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(COMPLEX_PT_CASE, is_complex, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return is_complex;
     }
+
+#undef COMPLEX_PT_CASE;
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop

--- a/lib/ome/files/VariantPixelBuffer.h
+++ b/lib/ome/files/VariantPixelBuffer.h
@@ -296,6 +296,11 @@ namespace ome
 #  pragma GCC diagnostic ignored "-Wswitch-default"
 #endif
 
+#define OME_FILES_VARIANTPIXELBUFFER_CREATEEXTENTS_CASE(maR, maProperty, maType) \
+          case ::ome::xml::model::enums::PixelType::maType:                      \
+            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::maType>::std_type>(extents, storage, pixeltype); \
+            break;
+
       /**
        * Create buffer from extents (internal storage).
        *
@@ -317,43 +322,18 @@ namespace ome
 
         switch(pixeltype)
           {
-          case ::ome::xml::model::enums::PixelType::INT8:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::std_type>(extents, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::INT16:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::std_type>(extents, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::INT32:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::std_type>(extents, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::UINT8:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::std_type>(extents, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::UINT16:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::std_type>(extents, storage, pixeltype);
-            break;
-          case :: ome::xml::model::enums::PixelType::UINT32:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::std_type>(extents, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::FLOAT:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::std_type>(extents, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::DOUBLE:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::std_type>(extents, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::BIT:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::std_type>(extents, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::COMPLEX:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::std_type>(extents, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::std_type>(extents, storage, pixeltype);
-            break;
+            BOOST_PP_SEQ_FOR_EACH(OME_FILES_VARIANTPIXELBUFFER_CREATEEXTENTS_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
           }
 
         return buf;
       }
+
+#undef OME_FILES_VARIANTPIXELBUFFER_CREATEEXTENTS_CASE
+
+#define OME_FILES_VARIANTPIXELBUFFER_CREATERANGE_CASE(maR, maProperty, maType) \
+          case ::ome::xml::model::enums::PixelType::maType:                    \
+            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::maType>::std_type>(range, storage, pixeltype); \
+            break;
 
       /**
        * Create buffer from ranges (helper).
@@ -375,43 +355,13 @@ namespace ome
 
         switch(pixeltype)
           {
-          case ::ome::xml::model::enums::PixelType::INT8:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT8>::std_type>(range, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::INT16:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT16>::std_type>(range, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::INT32:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::INT32>::std_type>(range, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::UINT8:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT8>::std_type>(range, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::UINT16:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT16>::std_type>(range, storage, pixeltype);
-            break;
-          case :: ome::xml::model::enums::PixelType::UINT32:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::UINT32>::std_type>(range, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::FLOAT:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::std_type>(range, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::DOUBLE:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::std_type>(range, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::BIT:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::BIT>::std_type>(range, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::COMPLEX:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::std_type>(range, storage, pixeltype);
-            break;
-          case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-            buf = makeBuffer<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::std_type>(range, storage, pixeltype);
-            break;
+            BOOST_PP_SEQ_FOR_EACH(OME_FILES_VARIANTPIXELBUFFER_CREATERANGE_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
           }
 
         return buf;
       }
+
+#undef OME_FILES_VARIANTPIXELBUFFER_CREATERANGE_CASE
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop

--- a/lib/ome/qtwidgets/TexelProperties.cpp
+++ b/lib/ome/qtwidgets/TexelProperties.cpp
@@ -52,6 +52,11 @@ namespace ome
 #  pragma GCC diagnostic ignored "-Wswitch-default"
 #endif
 
+#define INTERNALFORMAT_CASE(maR, maProperty, maType)                    \
+        case ::ome::xml::model::enums::PixelType::maType:               \
+          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::internal_format; \
+          break;
+
     GLenum
     textureInternalFormat(::ome::xml::model::enums::PixelType pixeltype)
     {
@@ -59,43 +64,18 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::internal_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::internal_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::internal_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::internal_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::internal_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::internal_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::internal_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::internal_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::internal_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::internal_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          internal_format = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::internal_format;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(INTERNALFORMAT_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return internal_format;
     }
+
+#undef INTERNALFORMAT_CASE
+
+#define EXTERNALFORMAT_CASE(maR, maProperty, maType)                    \
+        case ::ome::xml::model::enums::PixelType::maType:               \
+          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::external_format; \
+          break;
 
     GLenum
     textureExternalFormat(::ome::xml::model::enums::PixelType pixeltype)
@@ -104,43 +84,18 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::external_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::external_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::external_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::external_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::external_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::external_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::external_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::external_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::external_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::external_format;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          external_format = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::external_format;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(EXTERNALFORMAT_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return external_format;
     }
+
+#undef EXTERNALFORMAT_CASE
+
+#define EXTERNALTYPE_CASE(maR, maProperty, maType)                      \
+        case ::ome::xml::model::enums::PixelType::maType:               \
+          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::external_type; \
+          break;
 
     GLint
     textureExternalType(::ome::xml::model::enums::PixelType pixeltype)
@@ -149,43 +104,18 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::external_type;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::external_type;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::external_type;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::external_type;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::external_type;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::external_type;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::external_type;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::external_type;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::external_type;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::external_type;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          external_type = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::external_type;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(EXTERNALTYPE_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return external_type;
     }
+
+#undef EXTERNALTYPE_CASE
+
+#define FALLBACKTYPE_CASE(maR, maProperty, maType)                      \
+        case ::ome::xml::model::enums::PixelType::maType:               \
+          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::fallback_pixeltype; \
+          break;
 
     ::ome::xml::model::enums::PixelType
     texturePixelTypeFallback(::ome::xml::model::enums::PixelType pixeltype)
@@ -194,43 +124,18 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::fallback_pixeltype;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::fallback_pixeltype;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::fallback_pixeltype;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::fallback_pixeltype;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::fallback_pixeltype;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::fallback_pixeltype;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::fallback_pixeltype;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::fallback_pixeltype;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::fallback_pixeltype;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::fallback_pixeltype;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          fallback_pixeltype = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::fallback_pixeltype;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(FALLBACKTYPE_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return fallback_pixeltype;
     }
+
+#undef FALLBACKTYPE_CASE
+
+#define CONVERSION_CASE(maR, maProperty, maType)                        \
+        case ::ome::xml::model::enums::PixelType::maType:               \
+          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::conversion_required; \
+          break;
 
     bool
     textureConversionRequired(::ome::xml::model::enums::PixelType pixeltype)
@@ -239,43 +144,18 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::conversion_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::conversion_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::conversion_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::conversion_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::conversion_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::conversion_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::conversion_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::conversion_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::conversion_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::conversion_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          conversion_required = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::conversion_required;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(CONVERSION_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return conversion_required;
     }
+
+#undef CONVERSION_CASE
+
+#define NORMALIZATION_CASE(maR, maProperty, maType)                     \
+        case ::ome::xml::model::enums::PixelType::maType:               \
+          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::normalization_required; \
+          break;
 
     bool
     textureNormalizationRequired(::ome::xml::model::enums::PixelType pixeltype)
@@ -284,43 +164,18 @@ namespace ome
 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::normalization_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::normalization_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::normalization_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::normalization_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::normalization_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::normalization_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::normalization_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::normalization_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::normalization_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::normalization_required;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          normalization_required = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::normalization_required;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(NORMALIZATION_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return normalization_required;
     }
+
+#undef NORMALIZATION_CASE
+
+#define MINIFICATION_CASE(maR, maProperty, maType)                      \
+        case ::ome::xml::model::enums::PixelType::maType:               \
+          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::minification_filter; \
+          break;
 
     GLint
     textureMinificationFilter(::ome::xml::model::enums::PixelType pixeltype)
@@ -328,43 +183,18 @@ namespace ome
       GLint minification_filter = false; 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::minification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::minification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::minification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::minification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::minification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::minification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::minification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::minification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::minification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::minification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          minification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::minification_filter;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(MINIFICATION_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return minification_filter;
     }
+
+#undef MINIFICATION_CASE
+
+#define MAGNIFICATION_CASE(maR, maProperty, maType)                     \
+        case ::ome::xml::model::enums::PixelType::maType:               \
+          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::maType>::magnification_filter; \
+          break;
 
     GLint
     textureMagnificationFilter(::ome::xml::model::enums::PixelType pixeltype)
@@ -372,43 +202,13 @@ namespace ome
       GLint magnification_filter = false; 
       switch(pixeltype)
         {
-        case ::ome::xml::model::enums::PixelType::INT8:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT8>::magnification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT16:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT16>::magnification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::INT32:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::INT32>::magnification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT8:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT8>::magnification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT16:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT16>::magnification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::UINT32:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::UINT32>::magnification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::FLOAT:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::FLOAT>::magnification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLE:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>::magnification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::BIT:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::BIT>::magnification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::COMPLEX:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>::magnification_filter;
-          break;
-        case ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX:
-          magnification_filter = TexelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX>::magnification_filter;
-          break;
+          BOOST_PP_SEQ_FOR_EACH(MAGNIFICATION_CASE, size, OME_XML_MODEL_ENUMS_PIXELTYPE_VALUES);
         }
 
       return magnification_filter;
     }
+
+#undef MAGNIFICATION_CASE
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic pop


### PR DESCRIPTION
Use Boost.Preprocessor to remove large sets of hardcoded switch case statements.  This will make the code easier to adapt to model changes, as well as simplifiying it.

See also: https://github.com/openmicroscopy/bioformats/pull/2303

--------

Testing: The builds will fail horribly if this doesn't work, so checking they are green should be sufficient.  If you want to, you can check that the preprocessed source code looks nice.  See the other PR for the instructions.