### PR TITLE
remove extraneous hyphens from Debian package names

### DIFF
--- a/docs/sphinx/overview.txt
+++ b/docs/sphinx/overview.txt
@@ -138,7 +138,7 @@ for your platform to install the build dependencies:
 BSD Ports
   ``pkg install devel/boost-all devel/cmake science/hdf5 graphics/png lang/python textproc/py-genshi graphics/tiff textproc/xerces-c3 devel/git devel/googletest math/glm devel/qt5 graphics/graphviz devel/apache-ant java/openjdk7 textproc/py-sphinx print/texlive-full``
 Debian/Ubuntu
-  ``apt-get install build-essential libboost-all-dev cmake libhdf5-dev libpng12-dev python python-genshi libtiff5-dev libxerces-c-dev git libgtest-dev libglm-dev qt5-default libqt5-opengl5-dev libqt5-svg5-dev graphviz ant ant-contrib ant-optional openjdk-7-jdk openjdk-7-jre python-sphinx texlive-full``
+  ``apt-get install build-essential libboost-all-dev cmake libhdf5-dev libpng12-dev python python-genshi libtiff5-dev libxerces-c-dev git libgtest-dev libglm-dev qt5-default libqt5opengl5-dev libqt5svg5-dev graphviz ant ant-contrib ant-optional openjdk-7-jdk openjdk-7-jre python-sphinx texlive-full``
 
 Partial quick starts
 ^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Corrects the package names in the installation instructions. Compare with https://packages.debian.org/stable/libdevel/.