### PR TITLE
Upgrade to use the 2016-DEV0 API

### DIFF
--- a/docs/sphinx/examples/pixeldata.cpp
+++ b/docs/sphinx/examples/pixeldata.cpp
@@ -174,8 +174,8 @@ namespace
       return std::real(lhs) > std::real(rhs);
     }
 
-    // Get min and max for complex pixel types (COMPLEX and
-    // DOUBLECOMPLEX)
+    // Get min and max for complex pixel types (COMPLEXFLOAT and
+    // COMPLEXDOUBLE)
     // This is the same as for simple pixel types, except for the
     // addition of custom comparison functions and conversion of the
     // result to the real part.

--- a/lib/ome/files/PixelProperties.cpp
+++ b/lib/ome/files/PixelProperties.cpp
@@ -215,10 +215,10 @@ namespace ome
               if (is_integer)
                 throw std::logic_error("Complex pixel types must be floating point");
 
-              if (size == bytesPerPixel(::ome::xml::model::enums::PixelType::COMPLEX))
-                type = ::ome::xml::model::enums::PixelType::COMPLEX;
-              else if (size == bytesPerPixel(::ome::xml::model::enums::PixelType::DOUBLECOMPLEX))
-                type = ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX;
+              if (size == bytesPerPixel(::ome::xml::model::enums::PixelType::COMPLEXFLOAT))
+                type = ::ome::xml::model::enums::PixelType::COMPLEXFLOAT;
+              else if (size == bytesPerPixel(::ome::xml::model::enums::PixelType::COMPLEXDOUBLE))
+                type = ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE;
               else
                 throw std::runtime_error("No suitable complex pixel type found");
             }

--- a/lib/ome/files/PixelProperties.h
+++ b/lib/ome/files/PixelProperties.h
@@ -330,10 +330,10 @@ namespace ome
       }
     };
 
-    /// Properties of COMPLEX pixels.
+    /// Properties of COMPLEXFLOAT pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX> >
+    struct PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT> :
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT> >
     {
       /// Pixel type (standard language type).
       typedef std::complex<float> std_type;
@@ -353,10 +353,10 @@ namespace ome
       static const bool is_complex = true;
     };
 
-    /// Properties of DOUBLECOMPLEX pixels.
+    /// Properties of COMPLEXDOUBLE pixels.
     template<>
-    struct PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX> :
-      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX> >
+    struct PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE> :
+      public PixelPropertiesBase<PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE> >
     {
       /// Pixel type (standard language type).
       typedef std::complex<double> std_type;

--- a/lib/ome/files/VariantPixelBuffer.h
+++ b/lib/ome/files/VariantPixelBuffer.h
@@ -103,8 +103,8 @@ namespace ome
       /// Floating-point pixel types.
       typedef boost::mpl::vector< PixelProperties< ::ome::xml::model::enums::PixelType::FLOAT>,
                                   PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLE>,
-                                  PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEX>,
-                                  PixelProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX> > float_pixel_types;
+                                  PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT>,
+                                  PixelProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE> > float_pixel_types;
 
       /// Aggregate view of all numeric types.
       typedef boost::mpl::joint_view<integer_pixel_types,

--- a/lib/ome/files/tiff/IFD.cpp
+++ b/lib/ome/files/tiff/IFD.cpp
@@ -1031,9 +1031,9 @@ namespace ome
               case COMPLEX_FLOAT:
                 {
                   if (bits == 64)
-                    pt = PixelType::COMPLEX;
+                    pt = PixelType::COMPLEXFLOAT;
                   else if (bits == 128)
-                    pt = PixelType::DOUBLECOMPLEX;
+                    pt = PixelType::COMPLEXDOUBLE;
                   else
                     {
                       boost::format fmt("Bit depth %1% unsupported for complex floating point pixel type");
@@ -1079,8 +1079,8 @@ namespace ome
             fmt = FLOAT;
             break;
 
-          case PixelType::COMPLEX:
-          case PixelType::DOUBLECOMPLEX:
+          case PixelType::COMPLEXFLOAT:
+          case PixelType::COMPLEXDOUBLE:
             fmt = COMPLEX_FLOAT;
             break;
 

--- a/test/ome-files/formatreader.cpp
+++ b/test/ome-files/formatreader.cpp
@@ -1108,11 +1108,11 @@ FormatReaderTestParameters variant_params[] =
     FormatReaderTestParameters(PT::BIT,           ome::files::ENDIAN_BIG),
     FormatReaderTestParameters(PT::BIT,           ome::files::ENDIAN_LITTLE),
 
-    FormatReaderTestParameters(PT::COMPLEX,       ome::files::ENDIAN_BIG),
-    FormatReaderTestParameters(PT::COMPLEX,       ome::files::ENDIAN_LITTLE),
+    FormatReaderTestParameters(PT::COMPLEXFLOAT,  ome::files::ENDIAN_BIG),
+    FormatReaderTestParameters(PT::COMPLEXFLOAT,  ome::files::ENDIAN_LITTLE),
 
-    FormatReaderTestParameters(PT::DOUBLECOMPLEX, ome::files::ENDIAN_BIG),
-    FormatReaderTestParameters(PT::DOUBLECOMPLEX, ome::files::ENDIAN_LITTLE),
+    FormatReaderTestParameters(PT::COMPLEXDOUBLE, ome::files::ENDIAN_BIG),
+    FormatReaderTestParameters(PT::COMPLEXDOUBLE, ome::files::ENDIAN_LITTLE),
   };
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;

--- a/test/ome-files/formatwriter.cpp
+++ b/test/ome-files/formatwriter.cpp
@@ -154,7 +154,7 @@ namespace
   ome::xml::model::enums::PixelType init_adv_pt[] =
     {
       ome::xml::model::enums::PixelType::DOUBLE,
-      ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+      ome::xml::model::enums::PixelType::COMPLEXDOUBLE,
       ome::xml::model::enums::PixelType::BIT
     };
 
@@ -579,7 +579,7 @@ TEST_P(FormatWriterTest, SupportedPixelTypeDefault)
   EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16));
   EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT32));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLE));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLECOMPLEX));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::COMPLEXDOUBLE));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16));
 }
@@ -590,7 +590,7 @@ TEST_P(FormatWriterTest, SupportedPixelTypeByCodec)
   EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16, "default"));
   EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT32, "default"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLE, "default"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLECOMPLEX, "default"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::COMPLEXDOUBLE, "default"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT, "default"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16, "default"));
 
@@ -598,7 +598,7 @@ TEST_P(FormatWriterTest, SupportedPixelTypeByCodec)
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16, "advanced"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT32, "advanced"));
   EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLE, "advanced"));
-  EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLECOMPLEX, "advanced"));
+  EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::COMPLEXDOUBLE, "advanced"));
   EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT, "advanced"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16, "advanced"));
 
@@ -606,7 +606,7 @@ TEST_P(FormatWriterTest, SupportedPixelTypeByCodec)
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16, "invalid"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT32, "invalid"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLE, "invalid"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLECOMPLEX, "invalid"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::COMPLEXDOUBLE, "invalid"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT, "invalid"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16, "invalid"));
 }
@@ -667,11 +667,11 @@ FormatWriterTestParameters variant_params[] =
     FormatWriterTestParameters(PT::BIT,           ome::files::ENDIAN_BIG),
     FormatWriterTestParameters(PT::BIT,           ome::files::ENDIAN_LITTLE),
 
-    FormatWriterTestParameters(PT::COMPLEX,       ome::files::ENDIAN_BIG),
-    FormatWriterTestParameters(PT::COMPLEX,       ome::files::ENDIAN_LITTLE),
+    FormatWriterTestParameters(PT::COMPLEXFLOAT,  ome::files::ENDIAN_BIG),
+    FormatWriterTestParameters(PT::COMPLEXFLOAT,  ome::files::ENDIAN_LITTLE),
 
-    FormatWriterTestParameters(PT::DOUBLECOMPLEX, ome::files::ENDIAN_BIG),
-    FormatWriterTestParameters(PT::DOUBLECOMPLEX, ome::files::ENDIAN_LITTLE),
+    FormatWriterTestParameters(PT::COMPLEXDOUBLE, ome::files::ENDIAN_BIG),
+    FormatWriterTestParameters(PT::COMPLEXDOUBLE, ome::files::ENDIAN_LITTLE),
   };
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;

--- a/test/ome-files/pixel.h
+++ b/test/ome-files/pixel.h
@@ -66,45 +66,45 @@ pixel_value_complex(uint32_t value)
 
 template<>
 inline
-::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT,
                                           ::ome::files::ENDIAN_BIG>::type
-pixel_value< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+pixel_value< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT,
                                                        ::ome::files::ENDIAN_BIG>::type>(uint32_t value)
 {
-  return pixel_value_complex< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+  return pixel_value_complex< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT,
                                                                         ::ome::files::ENDIAN_BIG>::type>(value);
 }
 
 template<>
 inline
-::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT,
                                           ::ome::files::ENDIAN_LITTLE>::type
-pixel_value< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+pixel_value< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT,
                                                        ::ome::files::ENDIAN_LITTLE>::type>(uint32_t value)
 {
-  return pixel_value_complex< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEX,
+  return pixel_value_complex< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXFLOAT,
                                                                         ::ome::files::ENDIAN_LITTLE>::type>(value);
 }
 
 template<>
 inline
-::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE,
                                           ::ome::files::ENDIAN_BIG>::type
-pixel_value< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+pixel_value< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE,
                                                        ::ome::files::ENDIAN_BIG>::type>(uint32_t value)
 {
-  return pixel_value_complex< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+  return pixel_value_complex< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE,
                                                                         ::ome::files::ENDIAN_BIG>::type>(value);
 }
 
 template<>
 inline
-::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE,
                                           ::ome::files::ENDIAN_LITTLE>::type
-pixel_value< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+pixel_value< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE,
                                                        ::ome::files::ENDIAN_LITTLE>::type>(uint32_t value)
 {
-  return pixel_value_complex< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::DOUBLECOMPLEX,
+  return pixel_value_complex< ::ome::files::PixelEndianProperties< ::ome::xml::model::enums::PixelType::COMPLEXDOUBLE,
                                                                         ::ome::files::ENDIAN_LITTLE>::type>(value);
 }
 

--- a/test/ome-files/pixelbuffer-complex.cpp
+++ b/test/ome-files/pixelbuffer-complex.cpp
@@ -39,8 +39,8 @@
 #include "pixelbuffer.h"
 
 typedef ::testing::Types<
-  PixelEndianProperties<PT::COMPLEX,          ome::files::ENDIAN_BIG   >::type,
-  PixelEndianProperties<PT::COMPLEX,          ome::files::ENDIAN_LITTLE>::type,
-  PixelEndianProperties<PT::COMPLEX,          ome::files::ENDIAN_NATIVE>::type> TestTypes;
+  PixelEndianProperties<PT::COMPLEXFLOAT,     ome::files::ENDIAN_BIG   >::type,
+  PixelEndianProperties<PT::COMPLEXFLOAT,     ome::files::ENDIAN_LITTLE>::type,
+  PixelEndianProperties<PT::COMPLEXFLOAT,     ome::files::ENDIAN_NATIVE>::type> TestTypes;
 
 INSTANTIATE_TYPED_TEST_CASE_P(PixelBufferComplexTest, PixelBufferType, TestTypes);

--- a/test/ome-files/pixelbuffer-doublecomplex.cpp
+++ b/test/ome-files/pixelbuffer-doublecomplex.cpp
@@ -39,8 +39,8 @@
 #include "pixelbuffer.h"
 
 typedef ::testing::Types<
-  PixelEndianProperties<PT::DOUBLECOMPLEX,          ome::files::ENDIAN_BIG   >::type,
-  PixelEndianProperties<PT::DOUBLECOMPLEX,          ome::files::ENDIAN_LITTLE>::type,
-  PixelEndianProperties<PT::DOUBLECOMPLEX,          ome::files::ENDIAN_NATIVE>::type> TestTypes;
+  PixelEndianProperties<PT::COMPLEXDOUBLE,          ome::files::ENDIAN_BIG   >::type,
+  PixelEndianProperties<PT::COMPLEXDOUBLE,          ome::files::ENDIAN_LITTLE>::type,
+  PixelEndianProperties<PT::COMPLEXDOUBLE,          ome::files::ENDIAN_NATIVE>::type> TestTypes;
 
 INSTANTIATE_TYPED_TEST_CASE_P(PixelBufferDoubleComplexTest, PixelBufferType, TestTypes);

--- a/test/ome-files/pixelproperties.cpp
+++ b/test/ome-files/pixelproperties.cpp
@@ -95,8 +95,8 @@ typedef ::testing::Types<PixelTypeParam<PT::INT8,         int8_t>,
                          PixelTypeParam<PT::BIT,          bool>,
                          PixelTypeParam<PT::FLOAT,        float>,
                          PixelTypeParam<PT::DOUBLE,       double>,
-                         PixelTypeParam<PT::COMPLEX,      std::complex<float> >,
-                         PixelTypeParam<PT::DOUBLECOMPLEX,std::complex<double> > > TestTypes;
+                         PixelTypeParam<PT::COMPLEXFLOAT, std::complex<float> >,
+                         PixelTypeParam<PT::COMPLEXDOUBLE,std::complex<double> > > TestTypes;
 INSTANTIATE_TYPED_TEST_CASE_P(PixelPropertiesTypeTest, PixelPropertiesType, TestTypes);
 
 class PixelPropertiesTestParameters
@@ -202,8 +202,8 @@ PixelPropertiesTestParameters property_params[] =
     PixelPropertiesTestParameters(PT::BIT,           sizeof(bool),                 sizeof(bool)*8,                 false, true,   false),
     PixelPropertiesTestParameters(PT::FLOAT,         sizeof(float),                sizeof(float)*8,                true,  false,  false),
     PixelPropertiesTestParameters(PT::DOUBLE,        sizeof(double),               sizeof(double)*8,               true,  false,  false),
-    PixelPropertiesTestParameters(PT::COMPLEX,       sizeof(std::complex<float>),  sizeof(std::complex<float>)*8,  true,  false,  true),
-    PixelPropertiesTestParameters(PT::DOUBLECOMPLEX, sizeof(std::complex<double>), sizeof(std::complex<double>)*8, true,  false,  true)
+    PixelPropertiesTestParameters(PT::COMPLEXFLOAT,  sizeof(std::complex<float>),  sizeof(std::complex<float>)*8,  true,  false,  true),
+    PixelPropertiesTestParameters(PT::COMPLEXDOUBLE, sizeof(std::complex<double>), sizeof(std::complex<double>)*8, true,  false,  true)
   };
 
 class FindPixelTypeTestParameters
@@ -284,8 +284,8 @@ FindPixelTypeTestParameters find_params[] =
     FindPixelTypeTestParameters(PT::UINT32,        sizeof(uint32_t),             sizeof(uint32_t)*8,             false, true,   false,  false),
     FindPixelTypeTestParameters(PT::FLOAT,         sizeof(float),                sizeof(float)*8,                true,  false,  false,  false),
     FindPixelTypeTestParameters(PT::DOUBLE,        sizeof(double),               sizeof(double)*8,               true,  false,  false,  false),
-    FindPixelTypeTestParameters(PT::COMPLEX,       sizeof(std::complex<float>),  sizeof(std::complex<float>)*8,  true,  false,  true,   false),
-    FindPixelTypeTestParameters(PT::DOUBLECOMPLEX, sizeof(std::complex<double>), sizeof(std::complex<double>)*8, true,  false,  true,   false),
+    FindPixelTypeTestParameters(PT::COMPLEXFLOAT,  sizeof(std::complex<float>),  sizeof(std::complex<float>)*8,  true,  false,  true,   false),
+    FindPixelTypeTestParameters(PT::COMPLEXDOUBLE, sizeof(std::complex<double>), sizeof(std::complex<double>)*8, true,  false,  true,   false),
     FindPixelTypeTestParameters(PT::INT8,          0,                            0,                              true,  true,   false,  true),
     FindPixelTypeTestParameters(PT::INT8,          0,                            3,                              true,  true,   false,  true),
     FindPixelTypeTestParameters(PT::INT8,          0,                            3,                              true,  true,   true,   true),

--- a/test/ome-files/variantpixelbuffer.cpp
+++ b/test/ome-files/variantpixelbuffer.cpp
@@ -1031,8 +1031,8 @@ VariantPixelBufferTestParameters variant_params[] =
     VariantPixelBufferTestParameters(PT::FLOAT),
     VariantPixelBufferTestParameters(PT::DOUBLE),
     VariantPixelBufferTestParameters(PT::BIT),
-    VariantPixelBufferTestParameters(PT::COMPLEX),
-    VariantPixelBufferTestParameters(PT::DOUBLECOMPLEX)
+    VariantPixelBufferTestParameters(PT::COMPLEXFLOAT),
+    VariantPixelBufferTestParameters(PT::COMPLEXDOUBLE)
   };
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;


### PR DESCRIPTION
This is limited to the following enum changes:

- COMPLEX to COMPLEXFLOAT
- DOUBLECOMPLEX to COMPLEXDOUBLE