### PR TITLE
ome-files: Wrapper script computes absolute path portably

### DIFF
--- a/cmake/TemplateShellWrapper.cmake.in
+++ b/cmake/TemplateShellWrapper.cmake.in
@@ -87,15 +87,16 @@ fi
 # Determine installation prefix if unset, then determine paths for
 # programs, libraries, manpages etc.
 
+realpath() {
+  echo "$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+}
+
 if [ -n "$INSTALL_PREFIX" ] && [ -d "$INSTALL_PREFIX" ]; then
     :
 else
-    INSTALL_PREFIX="$(dirname "$prog")"
-    BINPATH="$INSTALL_BINDIR"
-    while [ "$BINPATH" != "." ]; do
-        INSTALL_PREFIX="$INSTALL_PREFIX/.."
-        BINPATH="$(dirname "$BINPATH")"
-    done
+    INSTALL_PREFIX="$(dirname "$(realpath "$prog")")"
+    INSTALL_PREFIX="${INSTALL_PREFIX%/${INSTALL_BINDIR}}"
+    BINPATH="${INSTALL_PREFIX}/${INSTALL_BINDIR}"
 fi
 
 case "$(uname -s)" in


### PR DESCRIPTION
https://trello.com/c/5HAmHU45/25-man-use-absolute-paths

This corrects the `ome-files` command wrapper to compute the installation prefix using a portable `realpath`, and then drop the bin path from it.  The previous approach worked but wasn't strictly portable and contained a non-canonical path containing relative parts which broke the "man" command on MacOS X.

--------

Testing: `ome-files --help` will now work on MacOS X.  Download the build from https://ci.openmicroscopy.org/view/Files-DEV/job/OME-FILES-CPP-DEV-merge-superbuild/BUILD_TYPE=Release,node=koi/lastSuccessfulBuild/artifact/artefacts/binaries/ and run `ome-files --help`.  It will now work.  The other `ome-files` options and commands like `info` will continue to work.