### PR TITLE
OMETIFFReader: Do not add BinData elements to Pixels

### DIFF
--- a/lib/ome/files/MetadataTools.cpp
+++ b/lib/ome/files/MetadataTools.cpp
@@ -548,7 +548,8 @@ namespace ome
           try
             {
               OMEXMLMetadata& omexml(dynamic_cast<OMEXMLMetadata&>(store));
-              if (omexml.getTiffDataCount(s) == 0)
+              if (omexml.getTiffDataCount(s) == 0 ||
+                  omexml.getPixelsBinDataCount(s) == 0)
                 addMetadataOnly(omexml, s);
             }
           catch (const std::bad_cast&)
@@ -592,7 +593,8 @@ namespace ome
           try
             {
               OMEXMLMetadata& omexml(dynamic_cast<OMEXMLMetadata&>(store));
-              if (omexml.getTiffDataCount(s) == 0)
+              if (omexml.getTiffDataCount(s) == 0 ||
+                  omexml.getPixelsBinDataCount(s) == 0)
                 addMetadataOnly(omexml, s);
             }
           catch (const std::bad_cast&)

--- a/lib/ome/files/MetadataTools.cpp
+++ b/lib/ome/files/MetadataTools.cpp
@@ -548,7 +548,8 @@ namespace ome
           try
             {
               OMEXMLMetadata& omexml(dynamic_cast<OMEXMLMetadata&>(store));
-              addMetadataOnly(omexml, s);
+              if (omexml.getTiffDataCount(s) == 0)
+                addMetadataOnly(omexml, s);
             }
           catch (const std::bad_cast&)
             {
@@ -591,7 +592,8 @@ namespace ome
           try
             {
               OMEXMLMetadata& omexml(dynamic_cast<OMEXMLMetadata&>(store));
-              addMetadataOnly(omexml, s);
+              if (omexml.getTiffDataCount(s) == 0)
+                addMetadataOnly(omexml, s);
             }
           catch (const std::bad_cast&)
             {

--- a/lib/ome/files/MetadataTools.cpp
+++ b/lib/ome/files/MetadataTools.cpp
@@ -548,7 +548,7 @@ namespace ome
           try
             {
               OMEXMLMetadata& omexml(dynamic_cast<OMEXMLMetadata&>(store));
-              if (omexml.getTiffDataCount(s) == 0 ||
+              if (omexml.getTiffDataCount(s) == 0 &&
                   omexml.getPixelsBinDataCount(s) == 0)
                 addMetadataOnly(omexml, s);
             }
@@ -593,7 +593,7 @@ namespace ome
           try
             {
               OMEXMLMetadata& omexml(dynamic_cast<OMEXMLMetadata&>(store));
-              if (omexml.getTiffDataCount(s) == 0 ||
+              if (omexml.getTiffDataCount(s) == 0 &&
                   omexml.getPixelsBinDataCount(s) == 0)
                 addMetadataOnly(omexml, s);
             }

--- a/lib/ome/files/in/OMETIFFReader.cpp
+++ b/lib/ome/files/in/OMETIFFReader.cpp
@@ -961,17 +961,25 @@ namespace ome
 
         // Set the metadata store Pixels.BigEndian attribute to match
         // the values we set in the core metadata
-        ome::compat::shared_ptr<ome::xml::meta::MetadataRetrieve> metadataRetrieve
-          (ome::compat::dynamic_pointer_cast<ome::xml::meta::MetadataRetrieve>(getMetadataStore()));
+        try
+          {
+            ome::compat::shared_ptr<ome::xml::meta::MetadataRetrieve> metadataRetrieve
+              (ome::compat::dynamic_pointer_cast<ome::xml::meta::MetadataRetrieve>(getMetadataStore()));
 
-        for (index_type i = 0; i < metadataRetrieve->getImageCount(); ++i)
-        {
+            for (index_type i = 0; i < metadataRetrieve->getImageCount(); ++i)
+              {
 #ifdef BOOST_BIG_ENDIAN
-          metadataStore->setPixelsBigEndian(1, i);
+                metadataStore->setPixelsBigEndian(1, i);
 #else // Little endian
-          metadataStore->setPixelsBigEndian(0, i);
+                metadataStore->setPixelsBigEndian(0, i);
 #endif
-        }
+              }
+          }
+        catch(const std::exception&)
+          {
+            // The metadata store doesn't support getImageCount so we
+            // can't meaningfully set anything.
+          }
       }
 
       void

--- a/lib/ome/files/in/OMETIFFReader.cpp
+++ b/lib/ome/files/in/OMETIFFReader.cpp
@@ -959,6 +959,8 @@ namespace ome
               }
           }
 
+        // Set the metadata store Pixels.BigEndian attribute to match
+        // the values we set in the core metadata
         ome::compat::shared_ptr<ome::xml::meta::MetadataRetrieve> metadataRetrieve
           (ome::compat::dynamic_pointer_cast<ome::xml::meta::MetadataRetrieve>(getMetadataStore()));
 

--- a/lib/ome/files/in/OMETIFFReader.cpp
+++ b/lib/ome/files/in/OMETIFFReader.cpp
@@ -1363,6 +1363,18 @@ namespace ome
           }
       }
 
+      ome::compat::shared_ptr<ome::xml::meta::MetadataStore>
+      OMETIFFReader::getMetadataStoreForConversion()
+      {
+        return getMetadataStore();
+      }
+
+      ome::compat::shared_ptr<ome::xml::meta::MetadataStore>
+      OMETIFFReader::getMetadataStoreForDisplay()
+      {
+        return getMetadataStore();
+      }
+
     }
   }
 }

--- a/lib/ome/files/in/OMETIFFReader.h
+++ b/lib/ome/files/in/OMETIFFReader.h
@@ -328,6 +328,45 @@ namespace ome
          */
         void
         fixDimensions(ome::xml::meta::BaseMetadata::index_type series);
+
+      public:
+        /**
+         * Get a MetadataStore suitable for writing.
+         *
+         * @note Historically, this method created metadata suitable
+         * for use with FormatWriter, but would possibly not generate
+         * valid OME-XML if both BinData and TiffData elements were
+         * present.  This is no longer the case; the general
+         * FormatReader::getMetadataStore() method will always create
+         * valid metadata which is suitable for use with FormatWriter,
+         * and so should be used instead.
+         *
+         * @returns the metadata store.
+         * @deprecated Use the general FormatReader::getMetadataStore() method.
+         * @todo Remove in 0.3
+         */
+        ome::compat::shared_ptr< ome::xml::meta::MetadataStore>
+        getMetadataStoreForConversion();
+
+        /**
+         * Get a MetadataStore suitable for display.
+         *
+         * @note Historically, this method removed certain elements
+         * for display purposes and was not be suitable for use with
+         * FormatWriter due to not containing required BinData
+         * BigEndian attributes pthis requirement has long been
+         * unnecessary].  This is no longer the case, and has never
+         * been the case for the C++ implementation; the general
+         * FormatReader::getMetadataStore() method will always create
+         * valid metadata which is suitable for both display and use
+         * with FormatWriter, and so should be used instead.
+         *
+         * @returns the metadata store.
+         * @deprecated Use the general FormatReader::getMetadataStore() method.
+         * @todo Remove in 0.3
+         */
+        ome::compat::shared_ptr< ome::xml::meta::MetadataStore>
+        getMetadataStoreForDisplay();
       };
 
 

--- a/lib/ome/files/in/OMETIFFReader.h
+++ b/lib/ome/files/in/OMETIFFReader.h
@@ -328,32 +328,6 @@ namespace ome
          */
         void
         fixDimensions(ome::xml::meta::BaseMetadata::index_type series);
-
-      public:
-        /**
-         * Get a MetadataStore suitable for writing.
-         *
-         * @note This will be suitable for use with FormatWriter, but
-         * will likely not generate valid OME-XML due to the
-         * likelihood of containing both BinData and TiffData
-         * elements.
-         *
-         * @returns the metadata store.
-         */
-        ome::compat::shared_ptr< ome::xml::meta::MetadataStore>
-        getMetadataStoreForConversion();
-
-        /**
-         * Get a MetadataStore suitable for display.
-         *
-         * @note This will not be suitable for use with FormatWriter
-         * due to not containing required BinData BigEndian
-         * attributes.
-         *
-         * @returns the metadata store.
-         */
-        ome::compat::shared_ptr< ome::xml::meta::MetadataStore>
-        getMetadataStoreForDisplay();
       };
 
 


### PR DESCRIPTION
Correct metadata validation errors in OMETIFFReader:

- Don't add BinData elements by setting the BigEndian property; set BigEndian on Pixels instead
- Move the BigEndian setting to `initFile` alongside all the other metadata setting
- Remove the unnecessary metadata functions
- Don't set MetadataOnly when TiffData elements are present, copying the Java logic.

Testing:

Run `ome-files info --omexml` on one of the problematic OME-TIFF files.  With this PR, the errors should no longer occur.