### PR TITLE
OMETIFFReader: Assorted multi-file fixes

### DIFF
--- a/lib/ome/files/in/OMETIFFReader.cpp
+++ b/lib/ome/files/in/OMETIFFReader.cpp
@@ -434,6 +434,7 @@ namespace ome
             // recurse with this file as the id.
             ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata> meta(createOMEXMLMetadata(*currentId));
             path firstTIFF(path(meta->getUUIDFileName(0, 0)));
+            close(false); // To force clearing of currentId.
             initFile(canonical(firstTIFF, dir));
             return;
           }

--- a/lib/ome/files/in/OMETIFFReader.cpp
+++ b/lib/ome/files/in/OMETIFFReader.cpp
@@ -1040,13 +1040,14 @@ namespace ome
                     try
                       {
                         uuidFilename = meta.getUUIDFileName(series, td);
+                        uuidFilename = canonical(uuidFilename, currentDir);
                       }
                     catch (const std::exception&)
                       {
                       }
                     if (fs::exists(uuidFilename))
                       {
-                        filename = canonical(uuidFilename, currentDir);
+                        filename = uuidFilename;
                       }
                     else
                       {

--- a/lib/ome/files/in/OMETIFFReader.cpp
+++ b/lib/ome/files/in/OMETIFFReader.cpp
@@ -1422,16 +1422,17 @@ namespace ome
       }
 
       ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
-      OMETIFFReader::readMetadata(const ome::files::tiff::TIFF& tiff) const
+      OMETIFFReader::readMetadata(const ome::files::tiff::TIFF& tiff)
       {
         return createOMEXMLMetadata(getImageDescription(tiff));
       }
 
       ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
-      OMETIFFReader::readMetadata(const boost::filesystem::path& id) const
+      OMETIFFReader::readMetadata(const boost::filesystem::path& id)
       {
-        if (checkSuffix(id, companion_suffixes))
+        if (!checkSuffix(id, companion_suffixes))
           {
+            addTIFF(id);
             const ome::compat::shared_ptr<const TIFF> tiff(getTIFF(id));
             return createOMEXMLMetadata(getImageDescription(*tiff));
           }

--- a/lib/ome/files/in/OMETIFFReader.cpp
+++ b/lib/ome/files/in/OMETIFFReader.cpp
@@ -1466,7 +1466,11 @@ namespace ome
             std::string omexml(getImageDescription(*tiff));
 
             // Basic sanity check before parsing.
-            if (omexml.size() == 0 || omexml[0] != '<' || omexml[omexml.size()-1] != '>')
+            std::string::size_type lpos = omexml.find_last_not_of(" \r\n\t\f\v");
+            if (omexml.size() == 0 ||
+                omexml[0] != '<' ||
+                lpos == std::string::npos ||
+                omexml[lpos] != '>')
               {
                 boost::format fmt("Badly formed or invalid XML document in ‘%1%’");
                 fmt % id.string();

--- a/lib/ome/files/in/OMETIFFReader.h
+++ b/lib/ome/files/in/OMETIFFReader.h
@@ -205,7 +205,7 @@ namespace ome
          * @returns the parsed metadata as a metadata store.
          */
         ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
-        readMetadata(const ome::files::tiff::TIFF& tiff) const;
+        readMetadata(const ome::files::tiff::TIFF& tiff);
 
         /**
          * Read metadata into metadata store from a TIFF or companion
@@ -215,7 +215,7 @@ namespace ome
          * @returns the parsed metadata as a metadata store.
          */
         ome::compat::shared_ptr< ::ome::xml::meta::OMEXMLMetadata>
-        readMetadata(const boost::filesystem::path& id) const;
+        readMetadata(const boost::filesystem::path& id);
 
         /**
          * Read and cache metadata.


### PR DESCRIPTION
With these changes, all 2016-06 sample data can be read successfully:

```
(for pat in "*.tif" "*.tiff" "*.tf2" "*.tf8" "*.btf" "*.companion.ome"; do find ~/images/ome-tiff/ome-schemas/2016-06 -name "$pat"; done) | while read f; do echo "TEST READ: $f"; ome-files info "$f" || echo "**FAIL**: $f" ; done
```

This will test opening of every file in every fileset.