### PR TITLE
ome-files: Support invocation via a symlink

### DIFF
--- a/cmake/TemplateShellWrapper.cmake.in
+++ b/cmake/TemplateShellWrapper.cmake.in
@@ -73,11 +73,9 @@ RELEASE_DATE="@OME_VCS_DATE_S@"
 
 # Program invoked as and command requested (if any)
 
-if [ "${0%"${0#?}"}" = "/" ]; then
-  prog="$0"
-else
-  prog="$(/bin/pwd)/$0"
-fi
+prog=$(readlink -f "$0" 2>/dev/null \
+  || perl -MCwd -le 'print Cwd::abs_path(shift)' "$0" 2>/dev/null \
+  || echo "$0")
 
 if [ "$#" -gt 0 ]; then
   cmd=$1


### PR DESCRIPTION
This copies the logic used by the bioformats java command wrappers, to permit use via a symlink.  This is needed to allow homebrew to correctly symlink `bin/ome-files` and then have it pick up all the correct paths.

Testing: Unpack a build, symlink `bin/ome-files` from somewhere else e.g. `/tmp/test`, and invoke `info` and `--usage` via the link.