### PR TITLE
TIFF wrapper fixes

### DIFF
--- a/lib/ome/files/tiff/Field.cpp
+++ b/lib/ome/files/tiff/Field.cpp
@@ -526,24 +526,39 @@ namespace ome
                            int                          readcount,
                            T&                           value)
         {
-          bool limit = false; // Special case for TIFFTAG_TRANSFERFUNCTION which can used 1 or 3 vectors.
           typename T::value_type::value_type *valueptr0, *valueptr1, *valueptr2;
           uint32_t count;
+          bool limit = false; // special case for TRANSFERFUNCTION
 
-          // Special case:
-          if (tag == TIFFTAG_COLORMAP ||
-              tag == TIFFTAG_TRANSFERFUNCTION)
+          // Special case COLORMAP
+          if (tag == TIFFTAG_COLORMAP)
+            {
+              uint16_t bps;
+              ifd->getRawField(TIFFTAG_BITSPERSAMPLE, &bps);
+              ifd->getRawField(tag, &valueptr0, &valueptr1, &valueptr2);
+              count = 1U << bps;
+            }
+          // Special case TRANSFERFUNCTION
+          else if (tag == TIFFTAG_TRANSFERFUNCTION)
             {
               uint16_t spp;
               ifd->getRawField(TIFFTAG_SAMPLESPERPIXEL, &spp);
               uint16_t bps;
               ifd->getRawField(TIFFTAG_BITSPERSAMPLE, &bps);
-              count = 1U << bps;
-              if (spp == 1)
-                limit = true;
-            }
+              uint16_t extrasamples, *ep = 0;
+              ifd->getRawFieldDefaulted(TIFFTAG_EXTRASAMPLES, &extrasamples, &ep);
 
-          if (readcount == TIFF_SPP)
+              if ((spp - extrasamples) == 1)
+                limit = true;
+
+              if(!limit)
+                ifd->getRawField(tag, &valueptr0, &valueptr1, &valueptr2);
+              else
+                ifd->getRawField(tag, &valueptr0);
+
+              count = 1U << bps;
+            }
+          else if (readcount == TIFF_SPP)
             {
               uint16_t spp;
               ifd->getRawField(TIFFTAG_SAMPLESPERPIXEL, &spp);
@@ -562,10 +577,7 @@ namespace ome
             }
           else
             {
-              if (!limit)
-                ifd->getRawField(tag, &valueptr0, &valueptr1, &valueptr2);
-              else
-                ifd->getRawField(tag, &valueptr0);
+              ifd->getRawField(tag, &valueptr0, &valueptr1, &valueptr2);
               count = static_cast<uint32_t>(readcount);
             }
 
@@ -593,19 +605,25 @@ namespace ome
               value[0].size() != value[2].size())
             throw Exception("Field array sizes are not equal");
 
-          bool limit = false; // Special case for TIFFTAG_TRANSFERFUNCTION which can used 1 or 3 vectors.
-
-          // Special case:
-          if (tag == TIFFTAG_COLORMAP ||
-              tag == TIFFTAG_TRANSFERFUNCTION)
+          // Special case COLORMAP
+          if (tag == TIFFTAG_COLORMAP)
+            {
+              ifd->setRawField(tag, value[0].data(), value[1].data(), value[2].data());
+            }
+          // Special case TRANSFERFUNCTION
+          else if (tag == TIFFTAG_TRANSFERFUNCTION)
             {
               uint16_t spp;
               ifd->getRawField(TIFFTAG_SAMPLESPERPIXEL, &spp);
-              if (spp == 1)
-                limit = true;
-            }
+              uint16_t extrasamples, *ep = 0;
+              ifd->getRawFieldDefaulted(TIFFTAG_EXTRASAMPLES, &extrasamples, &ep);
 
-          if (writecount == TIFF_SPP)
+              if ((spp - extrasamples) > 1)
+                ifd->setRawField(tag, value[0].data(), value[1].data(), value[2].data());
+              else
+                ifd->setRawField(tag, value[0].data());
+            }
+          else if (writecount == TIFF_SPP)
             {
               uint16_t spp;
               ifd->getRawField(TIFFTAG_SAMPLESPERPIXEL, &spp);
@@ -628,10 +646,7 @@ namespace ome
             }
           else
             {
-              if (!limit)
-                ifd->setRawField(tag, value[0].data(), value[1].data(), value[2].data());
-              else
-                ifd->setRawField(tag, value[0].data());
+              ifd->setRawField(tag, value[0].data(), value[1].data(), value[2].data());
             }
         }
 

--- a/lib/ome/files/tiff/Field.cpp
+++ b/lib/ome/files/tiff/Field.cpp
@@ -232,7 +232,7 @@ namespace ome
 
         const ::TIFFField *field = impl->getFieldInfo();
         if (field)
-          ret = (TIFFFieldPassCount(field));
+          ret = TIFFFieldPassCount(field) > 0;
 
         return ret;
       }

--- a/lib/ome/files/tiff/IFD.cpp
+++ b/lib/ome/files/tiff/IFD.cpp
@@ -754,6 +754,35 @@ namespace ome
       }
 
       void
+      IFD::getRawFieldDefaulted(tag_type tag,
+                                ...) const
+      {
+        ome::compat::shared_ptr<TIFF>& tiff = getTIFF();
+        ::TIFF *tiffraw = reinterpret_cast< ::TIFF *>(tiff->getWrapped());
+
+        Sentry sentry;
+
+        makeCurrent();
+
+        va_list ap;
+        va_start(ap, tag);
+
+        if (!tag)
+          {
+            boost::format fmt("Error getting field: Tag %1% is not valid");
+            fmt % tag;
+            throw Exception(fmt.str());
+          }
+
+        if (!TIFFVGetFieldDefaulted(tiffraw, tag, ap))
+          {
+            boost::format fmt("Error getting field: Tag %1% was not found");
+            fmt % tag;
+            sentry.error();
+          }
+      }
+
+      void
       IFD::setRawField(tag_type tag,
                        ...)
       {

--- a/lib/ome/files/tiff/IFD.h
+++ b/lib/ome/files/tiff/IFD.h
@@ -167,6 +167,21 @@ namespace ome
                     ...) const;
 
         /**
+         * Get a field by its tag number, falling back to default if
+         * unset.
+         *
+         * @note This should not be used except internally.  Use
+         * getField(TagCategory) instead which offers a type-safe
+         * interface on top of this lower-level TIFFGetField wrapper.
+         *
+         * @param tag the tag number.
+         * @param ... pointers to variables to store the value(s) in.
+         */
+        void
+        getRawFieldDefaulted(tag_type tag,
+                             ...) const;
+
+        /**
          * Set a field by its tag number.
          *
          * @note This should not be used except internally.  Use


### PR DESCRIPTION
The most important is the last commit to correct the handling of the `COLORMAP` tag.  This allows the OME-TIFF reader to read and display a file with a Windows Debug build without throwing a runtime error.  It was triggering a stack guard, and was also buggy (but silently working but incorrectly) on all other platforms.

Testing: Download Windows VS2015 64-bit debug build.  Run `bin\ome-files info \path\to\tiff` where the TIFF is an OME-TIFF with colourmap.  (bfconvert a CZI/LSM to OME-TIFF to get one if you don't have one.)  If you compare with the 0.2.1 release download, this this will run without problems while the release download will display an exception dialogue when the stack guard is tripped.