### PR TITLE
OMETIFFReader: Handle missing plane parameters

### DIFF
--- a/lib/ome/files/in/OMETIFFReader.cpp
+++ b/lib/ome/files/in/OMETIFFReader.cpp
@@ -964,7 +964,51 @@ namespace ome
             ms0->sizeT = 1U;
           }
 
-        fillMetadata(*metadataStore, *this, true, false);
+        fillMetadata(*metadataStore, *this, false, false);
+        seriesCount = meta->getImageCount();
+        for (index_type series = 0; series < seriesCount; ++series)
+          {
+            index_type planeCount = meta->getPlaneCount(series);
+            for (index_type plane = 0; plane < planeCount; ++plane)
+              {
+                // Make sure that TheZ, TheT and TheC are all set on
+                // any existing Planes.  Missing Planes are not added,
+                // and existing TheZ, TheC, and TheT values are not
+                // changed.
+                try
+                  {
+                    meta->getPlaneTheZ(series, plane);
+                  }
+                catch (const std::exception&)
+                  {
+                    metadataStore->setPlaneTheZ(0, series, plane);
+                    BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
+                      << "Setting unset Plane TheZ value to 0";
+                  }
+
+                try
+                  {
+                    meta->getPlaneTheT(series, plane);
+                  }
+                catch (const std::exception&)
+                  {
+                    metadataStore->setPlaneTheT(0, series, plane);
+                    BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
+                      << "Setting unset Plane TheT value to 0";
+                  }
+
+                try
+                  {
+                    meta->getPlaneTheC(series, plane);
+                  }
+                catch (const std::exception&)
+                  {
+                    metadataStore->setPlaneTheC(0, series, plane);
+                    BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
+                      << "Setting unset Plane TheC value to 0";
+                  }
+              }
+          }
 
         for (std::vector<boost::optional<Timestamp> >::const_iterator ts = acquiredDates.begin();
              ts != acquiredDates.end();


### PR DESCRIPTION
Don't make any assumptions regarding the ordering or presence of plane elements.

This is a conversion of https://github.com/openmicroscopy/bioformats/pull/2615/files for C++.

Testing: With a suitably broken OME-TIFF, you should see some warnings about setting unset plane parameters to zero.

This is the final (only) change for the 0.2.3 release.