### PR TITLE
Python wrapper

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -1,0 +1,9 @@
+from distutils.core import setup, Extension
+
+ext = Extension(
+    "ome_files",
+    sources=["src/ome_files.cpp"],
+    libraries=["ome-common", "ome-files", "ome-xml"],
+)
+
+setup(name="ome_files", ext_modules=[ext])

--- a/python/src/ome_files.cpp
+++ b/python/src/ome_files.cpp
@@ -10,41 +10,116 @@
 static PyObject *Error;
 
 
-static PyObject *
-get_image_count(PyObject *self, PyObject *args) {
-    const char *filename;
+typedef struct {
+    PyObject_HEAD
     ome::compat::shared_ptr<ome::files::FormatReader> reader;
-    PyObject* image_count;
-    if (!PyArg_ParseTuple(args, "s", &filename)) {
-        return NULL;
-    }
-    try {
-      reader = ome::compat::make_shared<ome::files::in::OMETIFFReader>();
-      reader->setId(std::string(filename));
-      image_count = PyInt_FromSize_t(reader->getImageCount());
-      reader->close();
-    } catch (const std::exception& e) {
-      PyErr_SetString(Error, e.what());
-      return NULL;
-    }
-    return image_count;
+} PyOMETIFFReader;
+
+
+static int
+PyOMETIFFReader_init(PyOMETIFFReader *self, PyObject *args, PyObject *kwds) {
+  self->reader = ome::compat::make_shared<ome::files::in::OMETIFFReader>();
+  return 0;
 }
 
 
+static PyObject *
+PyOMETIFFReader_setId(PyOMETIFFReader *self, PyObject *args) {
+  const char *filename;
+  if (!PyArg_ParseTuple(args, "s", &filename)) {
+    return NULL;
+  }
+  try {
+    self->reader->setId(std::string(filename));
+  } catch (const std::exception& e) {
+    PyErr_SetString(Error, e.what());
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
+
+static PyObject *
+PyOMETIFFReader_getImageCount(PyOMETIFFReader *self, PyObject *args) {
+  try {
+    return PyInt_FromSize_t(self->reader->getImageCount());
+  } catch (const std::exception& e) {
+    PyErr_SetString(Error, e.what());
+    return NULL;
+  }
+}
+
+
+static PyMethodDef PyOMETIFFReader_methods[] = {
+  {"set_id", (PyCFunction)PyOMETIFFReader_setId, METH_VARARGS,
+   "set the current file name"},
+  {"get_image_count", (PyCFunction)PyOMETIFFReader_getImageCount, METH_VARARGS,
+   "get the number of image planes in the current series"},
+  {NULL}                                       /* Sentinel */
+};
+
+
+PyTypeObject PyOMETIFFReaderType = {
+    PyObject_HEAD_INIT(NULL)
+    0,                                         /* ob_size */
+    "ome_files.OMETIFFReader",                 /* tp_name */
+    sizeof(PyOMETIFFReader),                   /* tp_basicsize */
+    0,                                         /* tp_itemsize */
+    0,                                         /* tp_dealloc */
+    0,                                         /* tp_print */
+    0,                                         /* tp_getattr */
+    0,                                         /* tp_setattr */
+    0,                                         /* tp_compare */
+    0,                                         /* tp_repr */
+    0,                                         /* tp_as_number */
+    0,                                         /* tp_as_sequence */
+    0,                                         /* tp_as_mapping */
+    0,                                         /* tp_hash */
+    0,                                         /* tp_call */
+    0,                                         /* tp_str */
+    0,                                         /* tp_getattro */
+    0,                                         /* tp_setattro */
+    0,                                         /* tp_as_buffer */
+    Py_TPFLAGS_DEFAULT | Py_TPFLAGS_BASETYPE,  /* tp_flags */
+    "PyOMETIFFReader objects",                 /* tp_doc */
+    0,                                         /* tp_traverse */
+    0,                                         /* tp_clear */
+    0,                                         /* tp_richcompare */
+    0,                                         /* tp_weaklistoffset */
+    0,                                         /* tp_iter */
+    0,                                         /* tp_iternext */
+    PyOMETIFFReader_methods,                   /* tp_methods */
+    0,                                         /* tp_members */
+    0,                                         /* tp_getset */
+    0,                                         /* tp_base */
+    0,                                         /* tp_dict */
+    0,                                         /* tp_descr_get */
+    0,                                         /* tp_descr_set */
+    0,                                         /* tp_dictoffset */
+    (initproc)PyOMETIFFReader_init,            /* tp_init */
+    0,                                         /* tp_alloc */
+    0,                                         /* tp_new */
+};
+
+
 static PyMethodDef OMEFilesMethods[] = {
-  {"get_image_count", get_image_count, METH_VARARGS,
-   "Open file and get image count"},
-  {NULL, NULL, 0, NULL} /* Sentinel */
+  {NULL}                                       /* Sentinel */
 };
 
 
 PyMODINIT_FUNC
 initome_files(void) {
   PyObject *m;
+  PyOMETIFFReaderType.tp_new = PyType_GenericNew;
+  if (PyType_Ready(&PyOMETIFFReaderType) < 0) {
+    return;
+  }
   m = Py_InitModule3("ome_files", OMEFilesMethods, "OME Files wrapper");
   if (!m) {
     return;
   }
+  Py_INCREF(&PyOMETIFFReaderType);
+  PyModule_AddObject(m, "OMETIFFReader", (PyObject *)&PyOMETIFFReaderType);
   Error = PyErr_NewException(const_cast<char*>("ome_files.Error"), NULL, NULL);
   Py_INCREF(Error);
   PyModule_AddObject(m, "Error", Error);

--- a/python/src/ome_files.cpp
+++ b/python/src/ome_files.cpp
@@ -1,0 +1,36 @@
+#include <Python.h>
+
+#include <string>
+
+#include <ome/compat/memory.h>
+#include <ome/files/FormatReader.h>
+#include <ome/files/in/OMETIFFReader.h>
+
+
+static PyObject *
+get_image_count(PyObject *self, PyObject *args) {
+    const char *filename;
+    ome::compat::shared_ptr<ome::files::FormatReader> reader;
+    PyObject* image_count;
+    if (!PyArg_ParseTuple(args, "s", &filename)) {
+        return NULL;
+    }
+    reader = ome::compat::make_shared<ome::files::in::OMETIFFReader>();
+    reader->setId(std::string(filename));
+    image_count = PyInt_FromSize_t(reader->getImageCount());
+    reader->close();
+    return image_count;
+}
+
+
+static PyMethodDef OMEFilesMethods[] = {
+  {"get_image_count", get_image_count, METH_VARARGS,
+   "Open file and get image count"},
+  {NULL, NULL, 0, NULL} /* Sentinel */
+};
+
+
+PyMODINIT_FUNC
+initome_files(void) {
+  Py_InitModule3("ome_files", OMEFilesMethods, "OME Files wrapper");
+}

--- a/python/src/ome_files.cpp
+++ b/python/src/ome_files.cpp
@@ -40,6 +40,29 @@ PyOMETIFFReader_setId(PyOMETIFFReader *self, PyObject *args) {
 
 
 static PyObject *
+PyOMETIFFReader_close(PyOMETIFFReader *self, PyObject *args, PyObject *kwds) {
+  PyObject *file_only = Py_False;
+  static const char *kwlist[] = {"file_only", NULL};
+  int fileOnly;
+  if (!PyArg_ParseTupleAndKeywords(
+        args, kwds, "|O", const_cast<char**>(kwlist), &file_only)) {
+    return NULL;
+  }
+  fileOnly = PyObject_IsTrue(file_only);
+  if (fileOnly < 0) {
+    return PyErr_Format(PyExc_TypeError, "could not convert argument to bool");
+  }
+  try {
+    self->reader->close(fileOnly);
+  } catch (const std::exception& e) {
+    PyErr_SetString(Error, e.what());
+    return NULL;
+  }
+  Py_RETURN_NONE;
+}
+
+
+static PyObject *
 PyOMETIFFReader_getImageCount(PyOMETIFFReader *self, PyObject *args) {
   try {
     return PyInt_FromSize_t(self->reader->getImageCount());
@@ -53,6 +76,9 @@ PyOMETIFFReader_getImageCount(PyOMETIFFReader *self, PyObject *args) {
 static PyMethodDef PyOMETIFFReader_methods[] = {
   {"set_id", (PyCFunction)PyOMETIFFReader_setId, METH_VARARGS,
    "set the current file name"},
+  {"close", (PyCFunction)PyOMETIFFReader_close, METH_VARARGS | METH_KEYWORDS,
+   "close(file_only=False): close the currently open file. "
+   "If file_only is False, also reset all internal state"},
   {"get_image_count", (PyCFunction)PyOMETIFFReader_getImageCount, METH_VARARGS,
    "get the number of image planes in the current series"},
   {NULL}                                       /* Sentinel */


### PR DESCRIPTION
Opening for initial feedback (this is just a minimal stub for now).

To test:

* Build the C++ libraries and install them to a `PREFIX`
* Move to the `python` subdir and run `python setup.py build_ext -I${PREFIX}/include -L${PREFIX}/lib -R${PREFIX}/lib`
* Move to `build/lib*` (e.g., `build/lib.macosx-10.11-x86_64-2.7` on my laptop)
* Add `${PREFIX}/lib` to the library path seen by the linker. On my Mac laptop, I ran `export DYLD_LIBRARY_PATH=${PREFIX}/lib`
* Open a Python shell and try something like the following:

```
>>> import ome_files
>>> reader = ome_files.OMETIFFReader()
>>> reader.get_image_count()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ome_files.Error: Current file should not be null; call setId() first
>>> reader.set_id("/path/to/img.ome.tif")
>>> count = reader.get_image_count()
>>> reader.close()
```

**Notes:**

(including a summary of initial comments from @rleigh-codelibre, @joshmoore and @sbesson)

*Wrapping strategy*

There are many ways to go about this. This is a "classic" Python extension, which uses the built-in C-level Python API. The main benefits of this approach w.r.t. using an external wrapping tool (boost.python, cython, swig, pybind11, ...) should be 1) maximum flexibility (i.e., full control of what's happening) and 2) no additional dependencies. The main drawback should be (possibly) more "manual" work. Note that we might need to integrate Numpy at some point, due to the presence of sophisticated numeric types.

*Which Python?*

This is a Python 2 extension. Do we want to support Python 2 or 3? They are mutually incompatible, so supporting both is an option but would require additional work

*Which repo?*

At least in its current state, the python wrapping code does not necessarily have to be here. We could start an `ome-files-py` repo.