### PR TITLE
Add support for TIFF compression

### DIFF
--- a/lib/ome/files/FormatWriter.h
+++ b/lib/ome/files/FormatWriter.h
@@ -271,7 +271,7 @@ namespace ome
        * @returns the supported pixel types.
        */
       virtual
-      const std::set<ome::xml::model::enums::PixelType>&
+      const std::set<ome::xml::model::enums::PixelType>
       getPixelTypes() const = 0;
 
       /**
@@ -281,7 +281,7 @@ namespace ome
        * @returns the supported pixel types.
        */
       virtual
-      const std::set<ome::xml::model::enums::PixelType>&
+      const std::set<ome::xml::model::enums::PixelType>
       getPixelTypes(const std::string& codec) const = 0;
 
       /**
@@ -314,6 +314,16 @@ namespace ome
       virtual
       const std::set<std::string>&
       getCompressionTypes() const  = 0;
+
+      /**
+       * Get supported compression types for a given pixel type.
+       *
+       * @param type the pixel type to use.
+       * @returns the supported compression types.
+       */
+      virtual
+      const std::set<std::string>&
+      getCompressionTypes(ome::xml::model::enums::PixelType type) const  = 0;
 
       /**
        * Set the compression type to use when writing.

--- a/lib/ome/files/detail/FormatWriter.cpp
+++ b/lib/ome/files/detail/FormatWriter.cpp
@@ -249,21 +249,26 @@ namespace ome
         return framesPerSecond;
       }
 
-      const std::set<ome::xml::model::enums::PixelType>&
+      const std::set<ome::xml::model::enums::PixelType>
       FormatWriter::getPixelTypes() const
       {
         return getPixelTypes("default");
       }
 
-      const std::set<ome::xml::model::enums::PixelType>&
+      const std::set<ome::xml::model::enums::PixelType>
       FormatWriter::getPixelTypes(const std::string& codec) const
       {
-        static std::set<ome::xml::model::enums::PixelType> empty;
-        WriterProperties::codec_pixel_type_map::const_iterator ci =
-          writerProperties.codec_pixel_types.find(codec);
-        if (ci != writerProperties.codec_pixel_types.end())
-          return ci->second;
-        return empty;
+        std::set<ome::xml::model::enums::PixelType> ret;
+
+        for(WriterProperties::pixel_compression_type_map::const_iterator ci = writerProperties.pixel_compression_types.begin();
+            ci != writerProperties.pixel_compression_types.end();
+            ++ci)
+          {
+            if (ci->second.find(codec) != ci->second.end())
+              ret.insert(ci->first);
+          }
+
+        return ret;
       }
 
       bool
@@ -276,9 +281,9 @@ namespace ome
       FormatWriter::isSupportedType(ome::xml::model::enums::PixelType type,
                                     const std::string&                codec) const
       {
-        std::set<ome::xml::model::enums::PixelType> pixel_types = getPixelTypes(codec);
-        std::set<ome::xml::model::enums::PixelType>::const_iterator i = pixel_types.find(type);
-        return i != pixel_types.end();
+        WriterProperties::pixel_compression_type_map::const_iterator ci = writerProperties.pixel_compression_types.find(type);
+        return ci != writerProperties.pixel_compression_types.end() &&
+          ci->second.find(codec) != ci->second.end();
       }
 
       void
@@ -519,6 +524,18 @@ namespace ome
       FormatWriter::getCompressionTypes() const
       {
         return writerProperties.compression_types;
+      }
+
+      const std::set<std::string>&
+      FormatWriter::getCompressionTypes(ome::xml::model::enums::PixelType type) const
+      {
+        static std::set<std::string> empty;
+
+        WriterProperties::pixel_compression_type_map::const_iterator ci = writerProperties.pixel_compression_types.find(type);
+        if (ci != writerProperties.pixel_compression_types.end())
+          return ci->second;
+        else
+          return empty;
       }
 
       bool

--- a/lib/ome/files/detail/FormatWriter.h
+++ b/lib/ome/files/detail/FormatWriter.h
@@ -56,8 +56,8 @@ namespace ome
       struct WriterProperties
       {
         /// Map of codec to pixel types.
-        typedef std::map<std::string,
-                         std::set<ome::xml::model::enums::PixelType> > codec_pixel_type_map;
+        typedef std::map<ome::xml::model::enums::PixelType,
+                         std::set<std::string> > pixel_compression_type_map;
 
         /// Format name.
         std::string name;
@@ -69,8 +69,8 @@ namespace ome
         std::vector<boost::filesystem::path> compression_suffixes;
         /// Supported compression types.
         std::set<std::string> compression_types;
-        /// Supported pixel types.
-        codec_pixel_type_map codec_pixel_types;
+        /// Supported compression codecs types for each pixel type.
+        pixel_compression_type_map pixel_compression_types;
         /// Stacks are supported.
         bool stacks;
 
@@ -87,7 +87,7 @@ namespace ome
           suffixes(),
           compression_suffixes(),
           compression_types(),
-          codec_pixel_types(),
+          pixel_compression_types(),
           stacks()
         {
           compression_suffixes.push_back(boost::filesystem::path(""));
@@ -372,11 +372,11 @@ namespace ome
         getFramesPerSecond() const;
 
         // Documented in superclass.
-        const std::set<ome::xml::model::enums::PixelType>&
+        const std::set<ome::xml::model::enums::PixelType>
         getPixelTypes() const;
 
         // Documented in superclass.
-        const std::set<ome::xml::model::enums::PixelType>&
+        const std::set<ome::xml::model::enums::PixelType>
         getPixelTypes(const std::string& codec) const;
 
         // Documented in superclass.
@@ -390,7 +390,10 @@ namespace ome
 
         // Documented in superclass.
         const std::set<std::string>&
-        getCompressionTypes() const ;
+        getCompressionTypes() const;
+
+        const std::set<std::string>&
+        getCompressionTypes(ome::xml::model::enums::PixelType type) const;
 
         // Documented in superclass.
         void

--- a/lib/ome/files/out/OMETIFFWriter.cpp
+++ b/lib/ome/files/out/OMETIFFWriter.cpp
@@ -51,6 +51,7 @@
 #include <ome/files/FormatTools.h>
 #include <ome/files/MetadataTools.h>
 #include <ome/files/out/OMETIFFWriter.h>
+#include <ome/files/tiff/Codec.h>
 #include <ome/files/tiff/Field.h>
 #include <ome/files/tiff/IFD.h>
 #include <ome/files/tiff/Tags.h>
@@ -105,16 +106,18 @@ namespace ome
           p.suffixes = std::vector<boost::filesystem::path>(suffixes,
                                                             suffixes + boost::size(suffixes));
 
-
           const PixelType::value_map_type& pv = PixelType::values();
-          std::set<ome::xml::model::enums::PixelType> pixeltypes;
           for (PixelType::value_map_type::const_iterator i = pv.begin();
                i != pv.end();
                ++i)
             {
-              pixeltypes.insert(i->first);
+              const std::vector<std::string>& ptcodecs = tiff::getCodecNames(i->first);
+              std::set<std::string> codecset(ptcodecs.begin(), ptcodecs.end());
+              // Supported by default with no compression
+              codecset.insert("default");
+              p.compression_types.insert(codecset.begin(), codecset.end());
+              p.pixel_compression_types.insert(WriterProperties::pixel_compression_type_map::value_type(i->first, codecset));
             }
-          p.codec_pixel_types.insert(WriterProperties::codec_pixel_type_map::value_type("default", pixeltypes));
 
           return p;
         }

--- a/lib/ome/files/tiff/Codec.h
+++ b/lib/ome/files/tiff/Codec.h
@@ -83,7 +83,7 @@ namespace ome
        * Get codec names registered with the TIFF library available
        * for a given pixel type.
        *
-       * @param pixetype the pixel type to compress.
+       * @param pixeltype the pixel type to compress.
        * @returns a list of available codec names.
        */
       const std::vector<std::string>&

--- a/lib/ome/files/tiff/Codec.h
+++ b/lib/ome/files/tiff/Codec.h
@@ -41,7 +41,9 @@
 #include <string>
 #include <vector>
 
-#include <ome/compat/cstdint.h>
+#include <ome/files/tiff/Types.h>
+
+#include <ome/xml/model/enums/PixelType.h>
 
 namespace ome
 {
@@ -58,17 +60,44 @@ namespace ome
         /// Codec name.
         std::string name;
         /// Codec number.
-        uint16_t    scheme;
+        Compression scheme;
       };
 
       /**
        * Get codecs registered with the TIFF library.
        *
-       * @returns a list of available codecs.
+       * @returns a list of available codecs (names and numbers).
        */
-      std::vector<Codec>
-      getConfiguredCodecs();
+      const std::vector<Codec>&
+      getCodecs();
 
+      /**
+       * Get codec names registered with the TIFF library.
+       *
+       * @returns a list of available codec names.
+       */
+      const std::vector<std::string>&
+      getCodecNames();
+
+      /**
+       * Get codec names registered with the TIFF library available
+       * for a given pixel type.
+       *
+       * @param pixetype the pixel type to compress.
+       * @returns a list of available codec names.
+       */
+      const std::vector<std::string>&
+      getCodecNames(ome::xml::model::enums::PixelType pixeltype);
+
+      /**
+       * Get the compression scheme enumeration for a codec name.
+       *
+       * @param name the codec name
+       * @returns the compression scheme for the name, or
+       * COMPRESSION_NONE if invalid.
+       */
+      Compression
+      getCodecScheme(const std::string& name);
     }
   }
 }

--- a/lib/ome/files/tiff/IFD.cpp
+++ b/lib/ome/files/tiff/IFD.cpp
@@ -605,6 +605,8 @@ namespace ome
         boost::optional<PlanarConfiguration> planarconfig;
         /// Photometric interpretation.
         boost::optional<PhotometricInterpretation> photometric;
+        /// Compression scheme.
+        boost::optional<Compression> compression;
         /// Current tile (for writing).
         tstrile_t ctile;
 
@@ -1198,6 +1200,25 @@ namespace ome
       {
         getField(PHOTOMETRIC).set(photometric);
         impl->photometric = photometric;
+      }
+
+      Compression
+      IFD::getCompression() const
+      {
+        if (!impl->compression)
+          {
+            Compression compression;
+            getField(COMPRESSION).get(compression);
+            impl->compression = compression;
+          }
+        return impl->compression.get();
+      }
+
+      void
+      IFD::setCompression(Compression compression)
+      {
+        getField(COMPRESSION).set(compression);
+        impl->compression = compression;
       }
 
       void

--- a/lib/ome/files/tiff/IFD.h
+++ b/lib/ome/files/tiff/IFD.h
@@ -449,6 +449,22 @@ namespace ome
         setPhotometricInterpretation(PhotometricInterpretation photometric);
 
         /**
+         * Get compression scheme.
+         *
+         * @returns the compression scheme.
+         */
+        Compression
+        getCompression() const;
+
+        /**
+         * Set compression scheme.
+         *
+         * @param compression the compression scheme.
+         */
+        void
+        setCompression(Compression compression);
+
+        /**
          * Read a whole image plane into a pixel buffer.
          *
          * @param buf the destination pixel buffer.

--- a/lib/ome/files/tiff/Types.h
+++ b/lib/ome/files/tiff/Types.h
@@ -108,16 +108,16 @@ namespace ome
           COMPRESSION_CCITTRLEW = 32771,   ///< 1 w/ word alignment.
           COMPRESSION_PACKBITS = 32773,    ///< Macintosh RLE.
           COMPRESSION_THUNDERSCAN = 32809, ///< ThunderScan RLE.
-          /// codes 32895-32898 are reserved for ANSI IT8 TIFF/IT <dkelly@apago.com).
+          // codes 32895-32898 are reserved for ANSI IT8 TIFF/IT <dkelly@apago.com).
           COMPRESSION_IT8CTPAD = 32895,    ///< IT8 CT w/padding.
           COMPRESSION_IT8LW = 32896,       ///< IT8 Linework RLE.
           COMPRESSION_IT8MP = 32897,       ///< IT8 Monochrome picture.
           COMPRESSION_IT8BL = 32898,       ///< IT8 Binary line art.
-          /// compression codes 32908-32911 are reserved for Pixar.
+          // compression codes 32908-32911 are reserved for Pixar.
           COMPRESSION_PIXARFILM = 32908,   ///< Pixar companded 10bit LZW.
           COMPRESSION_PIXARLOG = 32909,    ///< Pixar companded 11bit ZIP.
           COMPRESSION_DEFLATE = 32946,     ///< Deflate compression.
-          /// compression code 32947 is reserved for Oceana Matrix <dev@oceana.com>.
+          // compression code 32947 is reserved for Oceana Matrix <dev@oceana.com>.
           COMPRESSION_DCS = 32947,         ///< Kodak DCS encoding.
           COMPRESSION_JBIG = 34661,        ///< ISO JBIG.
           COMPRESSION_SGILOG = 34676,      ///< SGI Log Luminance RLE.

--- a/test/ome-files/formatwriter.cpp
+++ b/test/ome-files/formatwriter.cpp
@@ -166,7 +166,7 @@ namespace
         if (i->first == PixelType::BIT)
           codecset.insert("rle");
         if (i->first == PixelType::INT8 || i->first == PixelType::UINT8)
-          codecset.insert("jpeg");
+          codecset.insert("test-8bit-only");
 
         p.compression_types.insert(codecset.begin(), codecset.end());
         p.pixel_compression_types.insert(WriterProperties::pixel_compression_type_map::value_type(i->first, codecset));
@@ -630,11 +630,11 @@ TEST_P(FormatWriterTest, PixelTypesByCodec)
   const std::set<ome::xml::model::enums::PixelType> rle = w.getPixelTypes("rle");
   EXPECT_EQ(rle_pixel_types, rle);
 
-  std::set<ome::xml::model::enums::PixelType> jpeg_pixel_types;
-  jpeg_pixel_types.insert(PixelType::INT8);
-  jpeg_pixel_types.insert(PixelType::UINT8);
-  const std::set<ome::xml::model::enums::PixelType> jpeg = w.getPixelTypes("jpeg");
-  EXPECT_EQ(jpeg_pixel_types, jpeg);
+  std::set<ome::xml::model::enums::PixelType> test_8bit_pixel_types;
+  test_8bit_pixel_types.insert(PixelType::INT8);
+  test_8bit_pixel_types.insert(PixelType::UINT8);
+  const std::set<ome::xml::model::enums::PixelType> test_8bit = w.getPixelTypes("test-8bit-only");
+  EXPECT_EQ(test_8bit_pixel_types, test_8bit);
 
   const std::set<ome::xml::model::enums::PixelType> ipt = w.getPixelTypes("invalid");
   EXPECT_TRUE(ipt.empty());
@@ -669,13 +669,13 @@ TEST_P(FormatWriterTest, SupportedPixelTypeByCodec)
   EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT, "rle"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16, "rle"));
 
-  EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT8, "jpeg"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16, "jpeg"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT32, "jpeg"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLE, "jpeg"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::COMPLEXDOUBLE, "jpeg"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT, "jpeg"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16, "jpeg"));
+  EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT8, "test-8bit-only"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16, "test-8bit-only"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT32, "test-8bit-only"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLE, "test-8bit-only"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::COMPLEXDOUBLE, "test-8bit-only"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT, "test-8bit-only"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16, "test-8bit-only"));
 
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT8, "invalid"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16, "invalid"));

--- a/test/ome-files/formatwriter.cpp
+++ b/test/ome-files/formatwriter.cpp
@@ -144,26 +144,6 @@ operator<< (std::basic_ostream<charT,traits>& os,
 namespace
 {
 
-  ome::xml::model::enums::PixelType init_pt[] =
-    {
-      ome::xml::model::enums::PixelType::UINT8,
-      ome::xml::model::enums::PixelType::UINT16,
-      ome::xml::model::enums::PixelType::UINT32
-    };
-
-  ome::xml::model::enums::PixelType init_adv_pt[] =
-    {
-      ome::xml::model::enums::PixelType::DOUBLE,
-      ome::xml::model::enums::PixelType::COMPLEXDOUBLE,
-      ome::xml::model::enums::PixelType::BIT
-    };
-
-  std::set<ome::xml::model::enums::PixelType> default_pixel_types(init_pt,
-                                                                  init_pt + boost::size(init_pt));
-
-  std::set<ome::xml::model::enums::PixelType> advanced_pixel_types(init_adv_pt,
-                                                                   init_adv_pt + boost::size(init_adv_pt));
-
   WriterProperties
   test_properties()
   {
@@ -171,12 +151,26 @@ namespace
     p.suffixes.push_back("test");
     p.compression_suffixes.push_back("gz");
 
-    p.compression_types.insert("jpeg");
-    p.compression_types.insert("lzw");
-    p.compression_types.insert("rle");
+    const PixelType::value_map_type& pv = PixelType::values();
+    for (PixelType::value_map_type::const_iterator i = pv.begin();
+         i != pv.end();
+         ++i)
+      {
+        std::set<std::string> codecset;
+        if (i->first != PixelType::INT16 &&
+            i->first != PixelType::DOUBLE &&
+            i->first != PixelType::COMPLEXDOUBLE &&
+            i->first != PixelType::BIT)
+          codecset.insert("default");
+        codecset.insert("lzw");
+        if (i->first == PixelType::BIT)
+          codecset.insert("rle");
+        if (i->first == PixelType::INT8 || i->first == PixelType::UINT8)
+          codecset.insert("jpeg");
 
-    p.codec_pixel_types.insert(WriterProperties::codec_pixel_type_map::value_type("default", default_pixel_types));
-    p.codec_pixel_types.insert(WriterProperties::codec_pixel_type_map::value_type("advanced", advanced_pixel_types));
+        p.compression_types.insert(codecset.begin(), codecset.end());
+        p.pixel_compression_types.insert(WriterProperties::pixel_compression_type_map::value_type(i->first, codecset));
+      }
 
     p.stacks = true;
 
@@ -557,19 +551,92 @@ TEST_P(FormatWriterTest, OutputSequential)
   EXPECT_TRUE(w.getWriteSequentially());
 }
 
+TEST_P(FormatWriterTest, CompressionTypes)
+{
+  const std::set<std::string>& ctypes = w.getCompressionTypes();
+
+  std::cout << "Supported compression types:\n";
+  for (std::set<std::string>::const_iterator i = ctypes.begin();
+       i != ctypes.end();
+       ++i)
+    {
+      std::cout << "  " << *i << '\n';
+    }
+
+  // Dump per-pixel type codec list
+  const PixelType::value_map_type& pv = PixelType::values();
+  for (PixelType::value_map_type::const_iterator i = pv.begin();
+       i != pv.end();
+       ++i)
+    {
+      std::cout << "Pixel Type: " << i->second << '\n';
+      const std::set<std::string>& types = w.getCompressionTypes(i->first);
+      for (std::set<std::string>::const_iterator t = types.begin();
+           t != types.end();
+           ++t)
+        std::cout << "  " << *t << '\n';
+    }
+}
+
 TEST_P(FormatWriterTest, PixelTypesDefault)
 {
+  std::set<ome::xml::model::enums::PixelType> default_pixel_types;
+  const PixelType::value_map_type& pv = PixelType::values();
+  for (PixelType::value_map_type::const_iterator i = pv.begin();
+       i != pv.end();
+       ++i)
+    {
+      if (i->first != PixelType::INT16 &&
+          i->first != PixelType::DOUBLE &&
+          i->first != PixelType::COMPLEXDOUBLE &&
+          i->first != PixelType::BIT)
+      default_pixel_types.insert(i->first);
+    }
+
   const std::set<ome::xml::model::enums::PixelType>& pt = w.getPixelTypes();
   EXPECT_EQ(default_pixel_types, pt);
 }
 
 TEST_P(FormatWriterTest, PixelTypesByCodec)
 {
-  const std::set<ome::xml::model::enums::PixelType>& dpt = w.getPixelTypes("default");
+  const PixelType::value_map_type& pv = PixelType::values();
+
+  std::set<ome::xml::model::enums::PixelType> all_pixel_types;
+  for (PixelType::value_map_type::const_iterator i = pv.begin();
+       i != pv.end();
+       ++i)
+    all_pixel_types.insert(i->first);
+
+  std::set<ome::xml::model::enums::PixelType> default_pixel_types;
+  for (PixelType::value_map_type::const_iterator i = pv.begin();
+       i != pv.end();
+       ++i)
+    {
+      if (i->first != PixelType::INT16 &&
+          i->first != PixelType::DOUBLE &&
+          i->first != PixelType::COMPLEXDOUBLE &&
+          i->first != PixelType::BIT)
+      default_pixel_types.insert(i->first);
+    }
+
+  const std::set<ome::xml::model::enums::PixelType> dpt = w.getPixelTypes("default");
   EXPECT_EQ(default_pixel_types, dpt);
-  const std::set<ome::xml::model::enums::PixelType>& apt = w.getPixelTypes("advanced");
-  EXPECT_EQ(advanced_pixel_types, apt);
-  const std::set<ome::xml::model::enums::PixelType>& ipt = w.getPixelTypes("invalid");
+
+  const std::set<ome::xml::model::enums::PixelType> lzw = w.getPixelTypes("lzw");
+  EXPECT_EQ(all_pixel_types, lzw);
+
+  std::set<ome::xml::model::enums::PixelType> rle_pixel_types;
+  rle_pixel_types.insert(PixelType::BIT);
+  const std::set<ome::xml::model::enums::PixelType> rle = w.getPixelTypes("rle");
+  EXPECT_EQ(rle_pixel_types, rle);
+
+  std::set<ome::xml::model::enums::PixelType> jpeg_pixel_types;
+  jpeg_pixel_types.insert(PixelType::INT8);
+  jpeg_pixel_types.insert(PixelType::UINT8);
+  const std::set<ome::xml::model::enums::PixelType> jpeg = w.getPixelTypes("jpeg");
+  EXPECT_EQ(jpeg_pixel_types, jpeg);
+
+  const std::set<ome::xml::model::enums::PixelType> ipt = w.getPixelTypes("invalid");
   EXPECT_TRUE(ipt.empty());
 }
 
@@ -594,13 +661,21 @@ TEST_P(FormatWriterTest, SupportedPixelTypeByCodec)
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT, "default"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16, "default"));
 
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT8, "advanced"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16, "advanced"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT32, "advanced"));
-  EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLE, "advanced"));
-  EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::COMPLEXDOUBLE, "advanced"));
-  EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT, "advanced"));
-  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16, "advanced"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT8, "rle"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16, "rle"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT32, "rle"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLE, "rle"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::COMPLEXDOUBLE, "rle"));
+  EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT, "rle"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16, "rle"));
+
+  EXPECT_TRUE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT8, "jpeg"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16, "jpeg"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT32, "jpeg"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::DOUBLE, "jpeg"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::COMPLEXDOUBLE, "jpeg"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::BIT, "jpeg"));
+  EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::INT16, "jpeg"));
 
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT8, "invalid"));
   EXPECT_FALSE(w.isSupportedType(ome::xml::model::enums::PixelType::UINT16, "invalid"));

--- a/test/ome-files/ometiffwriter.cpp
+++ b/test/ome-files/ometiffwriter.cpp
@@ -64,31 +64,7 @@ using ome::files::tiff::TIFF;
 
 using namespace boost::filesystem;
 
-class TIFFTestParameters
-{
-public:
-
-  std::string file;
-  dimension_size_type sizeT;
-
-  TIFFTestParameters(const std::string& file,
-                     dimension_size_type sizeT):
-    file(file),
-    sizeT(sizeT)
-  {}
-};
-
-template<class charT, class traits>
-inline std::basic_ostream<charT,traits>&
-operator<< (std::basic_ostream<charT,traits>& os,
-            const TIFFTestParameters& tp)
-{
-  os << tp.file;
-
-  return os;
-}
-
-class TIFFWriterTest : public ::testing::TestWithParam<TileTestParameters>
+class TIFFWriterTest : public ::testing::TestWithParam<TIFFTestParameters>
 {
 public:
   ome::compat::shared_ptr<TIFF> tiff;
@@ -103,7 +79,7 @@ public:
   void
   SetUp()
   {
-    const TileTestParameters& params = GetParam();
+    const TIFFTestParameters& params = GetParam();
 
     path dir(PROJECT_BINARY_DIR "/test/ome-files/data");
     testfile = dir / (std::string("ometiffwriter-") + path(params.file).filename().string());
@@ -181,7 +157,7 @@ TEST_P(TIFFWriterTest, setId)
   tiffwriter.close();
 }
 
-std::vector<TileTestParameters> params(find_tile_tests());
+std::vector<TIFFTestParameters> params(find_tiff_tests());
 
 // Disable missing-prototypes warning for INSTANTIATE_TEST_CASE_P;
 // this is solely to work around a missing prototype in gtest.

--- a/test/ome-files/tiffsamples.cpp
+++ b/test/ome-files/tiffsamples.cpp
@@ -36,14 +36,16 @@
  * #L%
  */
 
+#include <ome/files/tiff/Types.h>
+
 #include "tiffsamples.h"
 
 using namespace boost::filesystem;
 
-std::vector<TileTestParameters>
-find_tile_tests()
+std::vector<TIFFTestParameters>
+find_tiff_tests()
 {
-  std::vector<TileTestParameters> params;
+  std::vector<TIFFTestParameters> params;
 
   path dir(PROJECT_BINARY_DIR "/test/ome-files/data");
   if (exists(dir) && is_directory(dir))
@@ -60,10 +62,11 @@ find_tile_tests()
           std::string wfile(wpath.string());
           if (ome::compat::regex_match(file, found, tile_match))
             {
-              TileTestParameters p;
+              TIFFTestParameters p;
               p.tile = true;
               p.file = file;
               p.wfile = wfile;
+              p.compression = ome::files::tiff::COMPRESSION_NONE;
 
               std::istringstream iwid(found[1]);
               if (!(iwid >> p.imagewidth))
@@ -89,10 +92,11 @@ find_tile_tests()
             }
           else if (ome::compat::regex_match(file, found, strip_match))
             {
-              TileTestParameters p;
+              TIFFTestParameters p;
               p.tile = false;
               p.file = file;
               p.wfile = wfile;
+              p.compression = ome::files::tiff::COMPRESSION_NONE;
 
               std::istringstream iwid(found[1]);
               if (!(iwid >> p.imagewidth))

--- a/test/ome-files/tiffsamples.h
+++ b/test/ome-files/tiffsamples.h
@@ -42,6 +42,7 @@
 #include <boost/filesystem.hpp>
 
 #include <ome/files/Types.h>
+#include <ome/files/tiff/Types.h>
 
 #include <ome/compat/regex.h>
 
@@ -50,7 +51,7 @@
 
 #include <vector>
 
-struct TileTestParameters
+struct TIFFTestParameters
 {
   bool tile;
   std::string file;
@@ -60,23 +61,25 @@ struct TileTestParameters
   ome::files::dimension_size_type imagelength;
   ome::files::dimension_size_type tilewidth;
   ome::files::dimension_size_type tilelength;
+  ome::files::tiff::Compression compression;
 };
 
 template<class charT, class traits>
 inline std::basic_ostream<charT,traits>&
 operator<< (std::basic_ostream<charT,traits>& os,
-            const TileTestParameters& p)
+            const TIFFTestParameters& p)
 {
   return os << p.file << " [" << p.wfile << "] ("
             << p.imagewidth << "x" << p.imagelength
             << (p.imageplanar ? " planar" : " chunky")
             << (p.tile ? " tiled " : " strips ")
             << p.tilewidth << "x" << p.tilelength
+            << " compression " << p.compression
             << ")";
 }
 
-extern std::vector<TileTestParameters>
-find_tile_tests();
+extern std::vector<TIFFTestParameters>
+find_tiff_tests();
 
 #endif // TEST_TIFFSAMPLES_H
 


### PR DESCRIPTION
- Allow introspection of TIFF codec support on a per-pixeltype basis; add `getCodecNames` and `getCodecScheme` to the tiff Codec support functions
- Allow the writer interface to query valid codecs for a given pixel type by adding `getCompressionTypes(PixelType)` which is a rather more useful variant than the existing `getPixelTypes(codec)` (which might be deprecated and removed).  In the common case, you might want to select a compression type for a given set of pixel data, but altering the pixel data to use a different type to support a certain codec is less common
- Add the supported codecs to the TIFF writers, so that they can be queried and set with the `FormatWriter` interface
- Add unit tests to test with LZW and Deflate compression for the core libtiff wrappers and the Minimal TIFF writer (the OME TIFF writer is derived from this and will work identically).

--------

Testing:

Should all be taken care of by the included unit tests.  Search for `FormatWriterTest.CompressionTypes` and `TIFFTest.FieldWrapCompression` for the tiff unit tests, and `TIFFWriter.CompressionTypes` for the full set of compression types we support (we exclude esoteric, incompatible and ancient ones).  Check that the per-pixeltype support makes sense (as output in the `TIFFWriter.CompressionTypes` test).

To confirm manually that compression is working, apply this patch on top of this branch:

```
diff --git a/test/ome-files/tiff.cpp b/test/ome-files/tiff.cpp
index ef8073a..8aa9fbc 100644
--- a/test/ome-files/tiff.cpp
+++ b/test/ome-files/tiff.cpp
@@ -1448,9 +1448,9 @@ class PixelTest : public ::testing::TestWithParam<PixelTestParameters>
   TearDown()
   {
     // Delete file (if any)
-    const PixelTestParameters& params = GetParam();
-    if (boost::filesystem::exists(params.filename))
-      boost::filesystem::remove(params.filename);
+    // const PixelTestParameters& params = GetParam();
+    // if (boost::filesystem::exists(params.filename))
+    //   boost::filesystem::remove(params.filename);
   }
 };
```

If using the superbuild, change into the `ome-files-build` directory, re-run the build with `make` or `ninja`, and then re-run the TIFF tests with `ctest -R tiff`.  This will not delete the generated TIFFs, so you can look at them to check the compression.  Example:

```
tiffinfo test/ome-files/data/data-layout-uint8-43x37planar-pi2-compDeflate-tile-32x32-ordered-optimal.tiff
```

In this case, the file uses Deflate compression and `tiffinfo` will confirm that.  You can also try viewing the file with Bio-Formats `showinf` to ensure the pixel data is correct.  Likewise for LZW compression.  Otherwise there will be no compression enabled (None or NoneDefault in the filename).  Look in `test/ome-files/data` to see what got generated (it's a random selection).

TODO: either as a followup or here, add example of enabling compression to our existing pixeldata sample.