### PR TITLE
Call assertId in getRGBChannelCount

### DIFF
--- a/lib/ome/files/detail/FormatReader.cpp
+++ b/lib/ome/files/detail/FormatReader.cpp
@@ -570,6 +570,7 @@ namespace ome
       dimension_size_type
       FormatReader::getRGBChannelCount(dimension_size_type channel) const
       {
+        assertId(currentId, true);
         return getCoreMetadata(getCoreIndex()).sizeC.at(channel);
       }
 


### PR DESCRIPTION
With this PR, if `getRGBChannelCount` is called before `setId`, the error message is `"Current file should not be null; call setId() first"`, consistently with other similar methods. Without this PR, the error message is `"vector"`.