### PR TITLE
set docs linkcheck timeout to 30s

### DIFF
--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -344,6 +344,10 @@ texinfo_documents = [
 
 # -- Options for the linkcheck builder ----------------------------------------
 
+# Timeout value, in seconds, for the linkcheck builder
+if not (sys.version_info[0] == 2 and sys.version_info[1] <= 5):
+    linkcheck_timeout = 30
+
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = []
 try:

--- a/docs/sphinx/conf.py.in
+++ b/docs/sphinx/conf.py.in
@@ -345,8 +345,7 @@ texinfo_documents = [
 # -- Options for the linkcheck builder ----------------------------------------
 
 # Timeout value, in seconds, for the linkcheck builder
-if not (sys.version_info[0] == 2 and sys.version_info[1] <= 5):
-    linkcheck_timeout = 30
+linkcheck_timeout = 30
 
 # Regular expressions that match URIs that should not be checked when doing a linkcheck build
 linkcheck_ignore = []


### PR DESCRIPTION
Ports same policy from `ome-model`. Docs CI should be green.

Also see https://github.com/ome/ome-cmake-superbuild/pull/114.