### PR TITLE
Add missing indirect includes

### DIFF
--- a/lib/ome/files/FormatReader.h
+++ b/lib/ome/files/FormatReader.h
@@ -44,6 +44,8 @@
 
 #include <boost/optional.hpp>
 
+#include <ome/compat/memory.h>
+
 #include <ome/files/CoreMetadata.h>
 #include <ome/files/FileInfo.h>
 #include <ome/files/FormatHandler.h>

--- a/lib/ome/files/MetadataTools.h
+++ b/lib/ome/files/MetadataTools.h
@@ -39,6 +39,8 @@
 
 #include <boost/filesystem/path.hpp>
 
+#include <ome/compat/memory.h>
+
 #include <ome/files/FormatReader.h>
 #include <ome/files/MetadataMap.h>
 #include <ome/files/Types.h>

--- a/test/ome-files/formatwriter.cpp
+++ b/test/ome-files/formatwriter.cpp
@@ -40,6 +40,8 @@
 
 #include <boost/range/size.hpp>
 
+#include <ome/compat/memory.h>
+
 #include <ome/files/FormatWriter.h>
 #include <ome/files/MetadataTools.h>
 #include <ome/files/VariantPixelBuffer.h>


### PR DESCRIPTION
Trivial fix to explicitly include a header currently included indirectly via the model headers.  This will break the build when the `basic-c++11` branch for ome-model is merged, since the needed header will then no longer be included.  It will be later removed by the `basic-c++11` branch for this component; the change here is to allow for a smooth transition to ensure compatibility for end users, by verifying that the compatibility headers work across the board during and after this transition.

Testing: Check builds are green.