### PR TITLE
Add missing ome/compat/memory.h includes

### DIFF
--- a/lib/ome/files/FormatReader.h
+++ b/lib/ome/files/FormatReader.h
@@ -52,6 +52,7 @@
 #include <ome/files/Types.h>
 
 #include <ome/compat/array.h>
+#include <ome/compat/memory.h>
 
 #include <ome/xml/meta/MetadataStore.h>
 

--- a/lib/ome/files/FormatWriter.h
+++ b/lib/ome/files/FormatWriter.h
@@ -53,6 +53,7 @@
 #include <ome/files/Types.h>
 
 #include <ome/compat/array.h>
+#include <ome/compat/memory.h>
 
 #include <ome/xml/meta/MetadataRetrieve.h>
 


### PR DESCRIPTION
Part of https://github.com/ome/ome-model/pull/25.  Needed to avoid compile failures due to using indirect includes of compatibility headers.