### PR TITLE
OMETIFFReader: Set interleaving according to IFD PlanarConfiguration

### DIFF
--- a/lib/ome/files/in/OMETIFFReader.cpp
+++ b/lib/ome/files/in/OMETIFFReader.cpp
@@ -809,7 +809,11 @@ namespace ome
 #else // Little endian
                 coreMeta->littleEndian = true;
 #endif
-                coreMeta->interleaved = false;
+
+                // This doesn't match the reality, but since subchannels are
+                // addressed as planes this is needed.
+                coreMeta->interleaved = (pifd->getPlanarConfiguration() == tiff::CONTIG);
+
                 coreMeta->indexed = false;
                 if (photometric == tiff::PALETTE)
                   {

--- a/lib/ome/files/out/OMETIFFWriter.cpp
+++ b/lib/ome/files/out/OMETIFFWriter.cpp
@@ -658,7 +658,7 @@ namespace ome
         ifd->setSamplesPerPixel(getRGBChannelCount(channel));
 
         const boost::optional<bool> interleaved(getInterleaved());
-        if (isRGB(channel) && interleaved && *interleaved)
+        if (interleaved && *interleaved)
           ifd->setPlanarConfiguration(tiff::CONTIG);
         else
           ifd->setPlanarConfiguration(tiff::SEPARATE);


### PR DESCRIPTION
Set the interleaved property correctly for the OME-TIFF reader (the other readers use the coremetadata conversion from till/Util.cpp which already has this behaviour).

Testing: Check builds are green.  There's no change to openbytes since the pixel buffer was already in the correct order; this simply corrects the isInterleaved property to match reality rather than fixing it to false.