### PR TITLE
TIFF read performance improvements

### DIFF
--- a/lib/ome/files/in/OMETIFFReader.cpp
+++ b/lib/ome/files/in/OMETIFFReader.cpp
@@ -1405,7 +1405,7 @@ namespace ome
       void
       OMETIFFReader::addTIFF(const boost::filesystem::path& tiff)
       {
-        tiffs.insert(std::make_pair(tiff, std::pair<ome::compat::shared_ptr<tiff::TIFF>, bool>(ome::compat::shared_ptr<tiff::TIFF>(), false)));
+        tiffs.insert(std::make_pair(tiff, ome::compat::shared_ptr<tiff::TIFF>()));
       }
 
       const ome::compat::shared_ptr<const ome::files::tiff::TIFF>
@@ -1426,19 +1426,18 @@ namespace ome
         // is uninitialised; true is invalid.  Used to prevent
         // repeated initialisation when the file is broken or
         // nonexistent.
-        if (!i->second.first || !i->second.second)
+        if (!i->second)
           {
             try
               {
-                i->second.first = tiff::TIFF::open(i->first, "r");
+                i->second = tiff::TIFF::open(i->first, "r");
               }
             catch (const ome::files::tiff::Exception&)
               {
-                i->second.second = true;
               }
           }
 
-        if (!i->second.first)
+        if (!i->second)
           {
             BOOST_LOG_SEV(logger, ome::logging::trivial::warning)
               << "Failed to open TIFF " << i->first.string();
@@ -1447,7 +1446,7 @@ namespace ome
             throw FormatException(fmt.str());
           }
 
-        return i->second.first;
+        return i->second;
       }
 
       bool
@@ -1461,10 +1460,10 @@ namespace ome
       OMETIFFReader::closeTIFF(const boost::filesystem::path& tiff)
       {
         tiff_map::iterator i = tiffs.find(tiff);
-        if (i->second.first)
+        if (i->second)
           {
-            i->second.first->close();
-            i->second.first = ome::compat::shared_ptr<ome::files::tiff::TIFF>();
+            i->second->close();
+            i->second = ome::compat::shared_ptr<ome::files::tiff::TIFF>();
           }
       }
 

--- a/lib/ome/files/in/OMETIFFReader.h
+++ b/lib/ome/files/in/OMETIFFReader.h
@@ -81,7 +81,7 @@ namespace ome
         typedef std::map<boost::filesystem::path, boost::filesystem::path> invalid_file_map;
 
         /// Map filename to open TIFF handle.
-        typedef std::map<boost::filesystem::path, std::pair<ome::compat::shared_ptr<ome::files::tiff::TIFF>, bool> > tiff_map;
+        typedef std::map<boost::filesystem::path, ome::compat::shared_ptr<ome::files::tiff::TIFF>> tiff_map;
 
         /// UUID to filename mapping.
         uuid_file_map files;

--- a/lib/ome/files/tiff/IFD.h
+++ b/lib/ome/files/tiff/IFD.h
@@ -101,6 +101,8 @@ namespace ome
          * @param tiff the source TIFF.
          * @param index the directory index.
          * @returns the open IFD.
+         *
+         * @deprecated Use openOffset() instead.
          */
         static ome::compat::shared_ptr<IFD>
         openIndex(ome::compat::shared_ptr<TIFF>& tiff,


### PR DESCRIPTION
- The OME-TIFF reader was supposed to be caching open TIFF reader instances, but in practice it was not doing the caching properly, and was repeatedly re-opening the same TIFF file instead of using the cached one; it now opens each TIFF once only and correctly retrieves it from the cache
- The TIFF libtiff wrapper class was not caching IFD offsets, leading to repeated linear scans through the IFDs when accessing by index; now we cache all IFDs up front which means a single linear scan on open and then constant-time access

The first was the most painful, giving a 6× improvement with BBBC/mitocheck data (120s → 20s).  The second was less impressive at 1.1× (20s → 18s) but still useful.

The TIFF caching does need to also think about closing TIFFs (we currently leave them open indefinitely).  We probably want to use some sort of LRU ordered list and only keep a certain number open to avoid running out of file descriptors in pathological scenarios.  May be useful to wait on having user-settable options in the API to fine-tune this.

The offset caching could also be further optimised if we wished, for example by only caching up to the requested index on demand rather than up front which would make a slight improvement for usage involving access to a specific plane or range of planes only.

Testing: Check builds are green.  Run `ome-files info` on the BBBC or mitocheck files and note the time taken to complete.  This should result in a significant reduction when compared with previous builds.