### PR TITLE
OMETIFFWriter: Enable compression support

### DIFF
--- a/lib/ome/files/out/OMETIFFWriter.cpp
+++ b/lib/ome/files/out/OMETIFFWriter.cpp
@@ -671,6 +671,10 @@ namespace ome
         else
           ifd->setPhotometricInterpretation(tiff::MIN_IS_BLACK);
 
+        const boost::optional<std::string> compression(getCompression());
+        if(compression)
+          ifd->setCompression(tiff::getCodecScheme(*compression));
+
         if (currentTIFF->second.ifdCount == 0)
           ifd->getField(ome::files::tiff::IMAGEDESCRIPTION).set(default_description);
       }

--- a/test/ome-files/ometiffwriter.cpp
+++ b/test/ome-files/ometiffwriter.cpp
@@ -126,6 +126,7 @@ TEST_P(TIFFWriterTest, setId)
   bool interleaved = true;
 
   tiffwriter.setInterleaved(interleaved);
+  tiffwriter.setCompression("Deflate");
 
   ASSERT_NO_THROW(tiffwriter.setId(testfile));
 


### PR DESCRIPTION
Enable TIFF compression when setting up each IFD.  This duplicates the existing support in MinimalTIFFWriter.  Tested in the unit test.

Testing: Check builds are green.  Run `tiffinfo` on one of the files under `ome-files-build/test/ome-files/data/ometiffwriter-*` and check that the compression scheme was set to deflate.  You should see:

```
  Compression Scheme: Deflate
```