### PR TITLE
Improve TIFF write performance

### DIFF
--- a/lib/ome/files/out/MinimalTIFFWriter.cpp
+++ b/lib/ome/files/out/MinimalTIFFWriter.cpp
@@ -240,9 +240,32 @@ namespace ome
         ifd->setImageWidth(getSizeX());
         ifd->setImageHeight(getSizeY());
 
-        ifd->setTileType(tiff::STRIP);
-        ifd->setTileWidth(getSizeX());
-        ifd->setTileHeight(1U);
+        // Default strip or tile size.  We base this upon a default
+        // chunk size of 64KiB for greyscale images, which will
+        // increase to 192KiB for 3 sample RGB images.  We use strips
+        // up to a width of 2048 after which tiles are used.
+        if(getSizeX() == 0)
+          {
+            // To avoid divide by zero.
+            ifd->setTileType(tiff::STRIP);
+            ifd->setTileWidth(getSizeX());
+            ifd->setTileHeight(1U);
+          }
+        else if(getSizeX() < 2048)
+          {
+            // Default to strips, mainly for compatibility with
+            // readers which don't support tiles.
+            ifd->setTileType(tiff::STRIP);
+            ifd->setTileWidth(getSizeX());
+            ifd->setTileHeight(65536U / getSizeX());
+          }
+        else
+          {
+            // Default to tiles.
+            ifd->setTileType(tiff::TILE);
+            ifd->setTileWidth(256U);
+            ifd->setTileHeight(256U);
+          }
 
         ome::compat::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());
 

--- a/lib/ome/files/out/MinimalTIFFWriter.cpp
+++ b/lib/ome/files/out/MinimalTIFFWriter.cpp
@@ -246,10 +246,7 @@ namespace ome
         // up to a width of 2048 after which tiles are used.
         if(getSizeX() == 0)
           {
-            // To avoid divide by zero.
-            ifd->setTileType(tiff::STRIP);
-            ifd->setTileWidth(getSizeX());
-            ifd->setTileHeight(1U);
+            throw FormatException("Can't set strip or tile size: SizeX is 0");
           }
         else if(getSizeX() < 2048)
           {

--- a/lib/ome/files/out/MinimalTIFFWriter.cpp
+++ b/lib/ome/files/out/MinimalTIFFWriter.cpp
@@ -253,7 +253,10 @@ namespace ome
             // readers which don't support tiles.
             ifd->setTileType(tiff::STRIP);
             ifd->setTileWidth(getSizeX());
-            ifd->setTileHeight(65536U / getSizeX());
+            uint32_t height = 65536U / getSizeX();
+            if (height == 0)
+              height = 1;
+            ifd->setTileHeight(height);
           }
 
         ome::compat::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());

--- a/lib/ome/files/out/MinimalTIFFWriter.cpp
+++ b/lib/ome/files/out/MinimalTIFFWriter.cpp
@@ -240,28 +240,20 @@ namespace ome
         ifd->setImageWidth(getSizeX());
         ifd->setImageHeight(getSizeY());
 
-        // Default strip or tile size.  We base this upon a default
+        // Default strip size.  We base this upon a default
         // chunk size of 64KiB for greyscale images, which will
-        // increase to 192KiB for 3 sample RGB images.  We use strips
-        // up to a width of 2048 after which tiles are used.
+        // increase to 192KiB for 3 sample RGB images.
         if(getSizeX() == 0)
           {
             throw FormatException("Can't set strip or tile size: SizeX is 0");
           }
-        else if(getSizeX() < 2048)
+        else
           {
             // Default to strips, mainly for compatibility with
             // readers which don't support tiles.
             ifd->setTileType(tiff::STRIP);
             ifd->setTileWidth(getSizeX());
             ifd->setTileHeight(65536U / getSizeX());
-          }
-        else
-          {
-            // Default to tiles.
-            ifd->setTileType(tiff::TILE);
-            ifd->setTileWidth(256U);
-            ifd->setTileHeight(256U);
           }
 
         ome::compat::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());

--- a/lib/ome/files/out/OMETIFFWriter.cpp
+++ b/lib/ome/files/out/OMETIFFWriter.cpp
@@ -645,9 +645,32 @@ namespace ome
         ifd->setImageWidth(getSizeX());
         ifd->setImageHeight(getSizeY());
 
-        ifd->setTileType(tiff::STRIP);
-        ifd->setTileWidth(getSizeX());
-        ifd->setTileHeight(1U);
+        // Default strip or tile size.  We base this upon a default
+        // chunk size of 64KiB for greyscale images, which will
+        // increase to 192KiB for 3 sample RGB images.  We use strips
+        // up to a width of 2048 after which tiles are used.
+        if(getSizeX() == 0)
+          {
+            // To avoid divide by zero.
+            ifd->setTileType(tiff::STRIP);
+            ifd->setTileWidth(getSizeX());
+            ifd->setTileHeight(1U);
+          }
+        else if(getSizeX() < 2048)
+          {
+            // Default to strips, mainly for compatibility with
+            // readers which don't support tiles.
+            ifd->setTileType(tiff::STRIP);
+            ifd->setTileWidth(getSizeX());
+            ifd->setTileHeight(65536U / getSizeX());
+          }
+        else
+          {
+            // Default to tiles.
+            ifd->setTileType(tiff::TILE);
+            ifd->setTileWidth(256U);
+            ifd->setTileHeight(256U);
+          }
 
         ome::compat::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());
 

--- a/lib/ome/files/out/OMETIFFWriter.cpp
+++ b/lib/ome/files/out/OMETIFFWriter.cpp
@@ -651,10 +651,7 @@ namespace ome
         // up to a width of 2048 after which tiles are used.
         if(getSizeX() == 0)
           {
-            // To avoid divide by zero.
-            ifd->setTileType(tiff::STRIP);
-            ifd->setTileWidth(getSizeX());
-            ifd->setTileHeight(1U);
+            throw FormatException("Can't set strip or tile size: SizeX is 0");
           }
         else if(getSizeX() < 2048)
           {

--- a/lib/ome/files/out/OMETIFFWriter.cpp
+++ b/lib/ome/files/out/OMETIFFWriter.cpp
@@ -658,7 +658,10 @@ namespace ome
             // readers which don't support tiles.
             ifd->setTileType(tiff::STRIP);
             ifd->setTileWidth(getSizeX());
-            ifd->setTileHeight(65536U / getSizeX());
+            uint32_t height = 65536U / getSizeX();
+            if (height == 0)
+              height = 1;
+            ifd->setTileHeight(height);
           }
 
         ome::compat::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());

--- a/lib/ome/files/out/OMETIFFWriter.cpp
+++ b/lib/ome/files/out/OMETIFFWriter.cpp
@@ -645,28 +645,20 @@ namespace ome
         ifd->setImageWidth(getSizeX());
         ifd->setImageHeight(getSizeY());
 
-        // Default strip or tile size.  We base this upon a default
+        // Default strip size.  We base this upon a default
         // chunk size of 64KiB for greyscale images, which will
-        // increase to 192KiB for 3 sample RGB images.  We use strips
-        // up to a width of 2048 after which tiles are used.
+        // increase to 192KiB for 3 sample RGB images.
         if(getSizeX() == 0)
           {
             throw FormatException("Can't set strip or tile size: SizeX is 0");
           }
-        else if(getSizeX() < 2048)
+        else
           {
             // Default to strips, mainly for compatibility with
             // readers which don't support tiles.
             ifd->setTileType(tiff::STRIP);
             ifd->setTileWidth(getSizeX());
             ifd->setTileHeight(65536U / getSizeX());
-          }
-        else
-          {
-            // Default to tiles.
-            ifd->setTileType(tiff::TILE);
-            ifd->setTileWidth(256U);
-            ifd->setTileHeight(256U);
           }
 
         ome::compat::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());


### PR DESCRIPTION
Make the C++ TIFF writers faster by using some simple heuristics to set the default strip and tile sizes.  Note: they are based solely upon the image dimensions and do not take pixel size or sample count into account.  We can do more sophisticated profiling later on and adjust the heuristics accordingly.  Also, once we have a proper tile/chunk-based replacement for saveBytes, we can make a number of assumptions and performance optimisations when the buffer size is of an expected and enforced size.

The current default: STRIP with a stripsize of 1.

For a 512×512 image, this means 512 strips of 1 row and when writing a whole plane, this means inserting 512 separate entries into the tile cache before flushing them out.  This is inefficient due to allocating 512 buffers and inserting them into the cache, and also into the coverage cache where 512 inserts into the R*Tree becomes expensive (it will automatically coalesce adjacent tiles to reduce the tree depth and hence insertion cost, but that also has a cost).

The new default: if sizex < 2048 use 64KiB pixel strips; else use 64KiB pixel tiles

For a 512×512 image, this means 4 strips of 128 rows, 4 inserts into the tile cache and 4 inserts into the coverage cache.

For a 1344×1024 image, this means 22 strips of 48 rows, 22 inserts into the tile cache and 22 inserts into the coverage cache.

Multiply this value by the pixel size and sample count to get the true storage size in bytes.

Testing: Try the ome-files-performance data.  This should show a decent improvement for the write performance; looked like it was saturating the disc when testing locally.  Should improve upon the previous runs.