### PR TITLE
MetadataTools: Resolve references after updating model objects

### DIFF
--- a/lib/ome/files/MetadataTools.cpp
+++ b/lib/ome/files/MetadataTools.cpp
@@ -263,6 +263,7 @@ namespace ome
       ome::xml::model::detail::OMEModel model;
       std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(meta->getRoot()));
       root->update(docroot, model);
+      model.resolveReferences();
 
       return meta;
     }


### PR DESCRIPTION
The existing uses of resolveReferences using the MetadataStore method of the same name has no effect.  This is because the OMEModel owned by the OMEXMLMetadataStore is never used for anything, because the helper methods are here in ome-files/formats-api on MetadataTools/OMEXMLService instead of the model.  Same problem for Java.  Ideally we'll move them over to where they belong.

This enables deserialisation of references.  Serialisation is still broken; later stages of deserialisation may also still need further work.

Testing: Check builds are green.  See https://github.com/ome/ome-model/pull/30/files