### PR TITLE
Fix copyright year range for main ome-files --version

### DIFF
--- a/cmake/TemplateCmdWrapper.cmake.in
+++ b/cmake/TemplateCmdWrapper.cmake.in
@@ -115,7 +115,7 @@ exit /b
 
 call :heredoc versiontext && goto versionexit:
 ome-files (OME Files) !VERSION_MAJOR!.!VERSION_MINOR!.!VERSION_PATCH!!VERSION_EXTRA!
-Copyright (c) 2006-2016 Open Microscopy Environment
+Copyright (c) 2006-2017 Open Microscopy Environment
 
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

--- a/cmake/TemplateCmdWrapper.cmake.in
+++ b/cmake/TemplateCmdWrapper.cmake.in
@@ -2,7 +2,7 @@
 REM #%L
 REM OME Files C++ libraries (shell wrapper)
 REM %%
-REM Copyright © 2015-2016 Open Microscopy Environment:
+REM Copyright © 2015-2017 Open Microscopy Environment:
 REM   - Massachusetts Institute of Technology
 REM   - National Institutes of Health
 REM   - University of Dundee

--- a/cmake/TemplateShellWrapper.cmake.in
+++ b/cmake/TemplateShellWrapper.cmake.in
@@ -3,7 +3,7 @@
 # #%L
 # OME Files C++ libraries (shell wrapper)
 # %%
-# Copyright © 2015 Open Microscopy Environment:
+# Copyright © 2015-2017 Open Microscopy Environment:
 #   - Massachusetts Institute of Technology
 #   - National Institutes of Health
 #   - University of Dundee
@@ -135,7 +135,7 @@ EOF
 version() {
   cat <<EOF
 ome-files (OME Files) $VERSION_MAJOR.$VERSION_MINOR.$VERSION_PATCH$VERSION_EXTRA
-Copyright © 2006–2016 Open Microscopy Environment
+Copyright © 2006–2017 Open Microscopy Environment
 
 This is free software; see the source for copying conditions.  There is NO
 warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.


### PR DESCRIPTION
See https://trello.com/c/4mdYwpIP/6-update-end-copyright-year

To test this PR check

```
ome-files --version
ome-files info --version
```

In both cases, the copyright should include 2017 in the year range