### PR TITLE
MinimalTIFFWriter: Interleaving behaviour is the same as OME-TIFF

### DIFF
--- a/lib/ome/files/out/MinimalTIFFWriter.cpp
+++ b/lib/ome/files/out/MinimalTIFFWriter.cpp
@@ -265,7 +265,7 @@ namespace ome
         ifd->setSamplesPerPixel(getRGBChannelCount(channel));
 
         const boost::optional<bool> interleaved(getInterleaved());
-        if (isRGB(channel) && interleaved && *interleaved)
+        if (interleaved && *interleaved)
           ifd->setPlanarConfiguration(tiff::CONTIG);
         else
           ifd->setPlanarConfiguration(tiff::SEPARATE);


### PR DESCRIPTION
Same fix as for https://github.com/ome/ome-files-cpp/pull/49 for ome-tiff

Testing: Check builds are green.