### PR TITLE
getZCTCoords: check index vs max value

### DIFF
--- a/lib/ome/files/FormatTools.cpp
+++ b/lib/ome/files/FormatTools.cpp
@@ -426,6 +426,13 @@ namespace ome
                  dimension_size_type num,
                  dimension_size_type index)
     {
+      if (index >= num)
+	{
+	  boost::format fmt("Invalid index: %1%");
+	  fmt % index;
+	  throw std::logic_error(fmt.str());
+	}
+
       dimension_size_type iz = 0, it = 0, ic = 0;
       validate_dimensions(order, zSize, cSize, tSize, num, iz, ic, it);
 

--- a/lib/ome/files/FormatTools.cpp
+++ b/lib/ome/files/FormatTools.cpp
@@ -58,7 +58,7 @@ namespace ome
       {
         boost::format fmt("Invalid %1% %2%: %3%");
         fmt % dim % what % value;
-        throw std::logic_error(fmt.str());
+        throw std::out_of_range(fmt.str());
       }
 
       void
@@ -69,7 +69,7 @@ namespace ome
       {
         boost::format fmt("Invalid %1% %2%: %3%/%4%");
         fmt % dim % what % value1 % value2;
-        throw std::logic_error(fmt.str());
+        throw std::out_of_range(fmt.str());
       }
 
       void
@@ -430,7 +430,7 @@ namespace ome
 	{
 	  boost::format fmt("Invalid index: %1%");
 	  fmt % index;
-	  throw std::logic_error(fmt.str());
+	  throw std::out_of_range(fmt.str());
 	}
 
       dimension_size_type iz = 0, it = 0, ic = 0;

--- a/test/ome-files/formatreader.cpp
+++ b/test/ome-files/formatreader.cpp
@@ -649,6 +649,7 @@ TEST_P(FormatReaderTest, FlatSeries)
   EXPECT_EQ(1U, r.getResolutionCount());
   EXPECT_EQ(0U, r.getResolution());
   EXPECT_NO_THROW(r.setResolution(0));
+  EXPECT_THROW(r.getZCTCoords(r.getImageCount()), std::logic_error);
 
   static const std::vector<dims> coords
     {

--- a/test/ome-files/formatreader.cpp
+++ b/test/ome-files/formatreader.cpp
@@ -649,7 +649,10 @@ TEST_P(FormatReaderTest, FlatSeries)
   EXPECT_EQ(1U, r.getResolutionCount());
   EXPECT_EQ(0U, r.getResolution());
   EXPECT_NO_THROW(r.setResolution(0));
-  EXPECT_THROW(r.getZCTCoords(r.getImageCount()), std::logic_error);
+  EXPECT_THROW(r.getZCTCoords(r.getImageCount()), std::out_of_range);
+  EXPECT_THROW(r.getIndex(r.getSizeZ(), 0, 0), std::out_of_range);
+  EXPECT_THROW(r.getIndex(0, r.getEffectiveSizeC(), 0), std::out_of_range);
+  EXPECT_THROW(r.getIndex(0, 0, r.getSizeT()), std::out_of_range);
 
   static const std::vector<dims> coords
     {


### PR DESCRIPTION
Changes `getZCTCoords` to throw when the given index is too big.