### PR TITLE
Add Tiling API for writers

### DIFF
--- a/docs/sphinx/examples/metadata-formatwriter.cpp
+++ b/docs/sphinx/examples/metadata-formatwriter.cpp
@@ -192,6 +192,8 @@ main(int argc, char *argv[])
           // Set writer options before opening a file
           writer->setMetadataRetrieve(meta);
           writer->setInterleaved(false);
+          writer->setTileSizeX(256);
+          writer->setTileSizeY(256);
 
           // Open the file
           writer->setId(filename);

--- a/lib/ome/files/FormatWriter.h
+++ b/lib/ome/files/FormatWriter.h
@@ -397,51 +397,14 @@ namespace ome
        * Set the requested tile width.
        *
        * The requested tile width may not be supported by the
-       * underlying file format.  Call getEffectiveTileSizeX() to get
-       * the size in use by the writer.
+       * underlying file format.  Call getTileSizeX() to get the
+       * effective size in use by the writer, or use the return value.
        *
-       * @param size the requested tile width.
+       * @param size the effective tile width.
        **/
       virtual
-      void
+      dimension_size_type
       setTileSizeX(boost::optional<dimension_size_type> size) = 0;
-
-      /**
-       * Get the requested tile width.
-       *
-       * @note Call getEffectiveTileSizeX() to get the size in use by
-       * the writer.
-       *
-       * @returns the requested tile width.
-       **/
-      virtual
-      boost::optional<dimension_size_type>
-      getTileSizeX() const = 0;
-
-      /**
-       * Set the requested tile height.
-       *
-       * The requested tile height may not be supported by the
-       * underlying file format.  Call getEffectiveTileSizeY() to get
-       * the size in use by the writer.
-       *
-       * @param size the requested tile height.
-       **/
-      virtual
-      void
-      setTileSizeY(boost::optional<dimension_size_type> size) = 0;
-
-      /**
-       * Get the requested tile height.
-       *
-       * @note Call getEffectiveTileSizeY() to get the size in use by
-       * the writer.
-       *
-       * @returns the requested tile height.
-       **/
-      virtual
-      boost::optional<dimension_size_type>
-      getTileSizeY() const = 0;
 
       /**
        * Get the effective tile width.
@@ -457,8 +420,20 @@ namespace ome
        **/
       virtual
       dimension_size_type
-      getEffectiveTileSizeX() const = 0;
+      getTileSizeX() const = 0;
 
+      /**
+       * Set the requested tile height.
+       *
+       * The requested tile height may not be supported by the
+       * underlying file format.  Call getTileSizeY() to get the
+       * effective size in use by the writer, or use the return value.
+       *
+       * @param size the effective tile height.
+       **/
+      virtual
+      dimension_size_type
+      setTileSizeY(boost::optional<dimension_size_type> size) = 0;
 
       /**
        * Get the effective tile height.
@@ -474,7 +449,7 @@ namespace ome
        **/
       virtual
       dimension_size_type
-      getEffectiveTileSizeY() const = 0;
+      getTileSizeY() const = 0;
     };
 
   }

--- a/lib/ome/files/FormatWriter.h
+++ b/lib/ome/files/FormatWriter.h
@@ -392,6 +392,89 @@ namespace ome
       virtual
       bool
       getWriteSequentially() const = 0;
+
+      /**
+       * Set the requested tile width.
+       *
+       * The requested tile width may not be supported by the
+       * underlying file format.  Call getEffectiveTileSizeX() to get
+       * the size in use by the writer.
+       *
+       * @param size the requested tile width.
+       **/
+      virtual
+      void
+      setTileSizeX(boost::optional<dimension_size_type> size) = 0;
+
+      /**
+       * Get the requested tile width.
+       *
+       * @note Call getEffectiveTileSizeX() to get the size in use by
+       * the writer.
+       *
+       * @returns the requested tile width.
+       **/
+      virtual
+      boost::optional<dimension_size_type>
+      getTileSizeX() const = 0;
+
+      /**
+       * Set the requested tile height.
+       *
+       * The requested tile height may not be supported by the
+       * underlying file format.  Call getEffectiveTileSizeY() to get
+       * the size in use by the writer.
+       *
+       * @param size the requested tile height.
+       **/
+      virtual
+      void
+      setTileSizeY(boost::optional<dimension_size_type> size) = 0;
+
+      /**
+       * Get the requested tile height.
+       *
+       * @note Call getEffectiveTileSizeY() to get the size in use by
+       * the writer.
+       *
+       * @returns the requested tile height.
+       **/
+      virtual
+      boost::optional<dimension_size_type>
+      getTileSizeY() const = 0;
+
+      /**
+       * Get the effective tile width.
+       *
+       * This is intended for use with saveBytes().  Unlike
+       * getTileSizeX(), which returns the size set by the caller (if
+       * any), this method returns the size in use by the reader.  If
+       * the width requested is unsupported, the writer may set the
+       * nearest supported size, or the full image width or greater if
+       * no smaller tile sizes are supported.
+       *
+       * @returns the effective tile width.
+       **/
+      virtual
+      dimension_size_type
+      getEffectiveTileSizeX() const = 0;
+
+
+      /**
+       * Get the effective tile height.
+       *
+       * This is intended for use with saveBytes().  Unlike
+       * getTileSizeY(), which returns the size set by the caller (if
+       * any), this method returns the size in use by the reader.  If
+       * the height requested is unsupported, the writer may set the
+       * nearest supported size, or the full image height or greater if
+       * no smaller tile sizes are supported.
+       *
+       * @returns the effective tile height.
+       **/
+      virtual
+      dimension_size_type
+      getEffectiveTileSizeY() const = 0;
     };
 
   }

--- a/lib/ome/files/detail/FormatWriter.cpp
+++ b/lib/ome/files/detail/FormatWriter.cpp
@@ -86,6 +86,8 @@ namespace ome
         interleaved(boost::none),
         sequential(false),
         framesPerSecond(0),
+        tile_size_x(boost::none),
+        tile_size_y(boost::none),
         metadataRetrieve(std::make_shared<DummyMetadata>())
       {
         assertId(currentId, false);
@@ -542,6 +544,51 @@ namespace ome
       FormatWriter::canDoStacks() const
       {
         return writerProperties.stacks;
+      }
+
+      void
+      FormatWriter::setTileSizeX(boost::optional<dimension_size_type> size)
+      {
+        tile_size_x = size;
+      }
+
+      boost::optional<dimension_size_type>
+      FormatWriter::getTileSizeX() const
+      {
+        return tile_size_x;
+      }
+
+      void
+      FormatWriter::setTileSizeY(boost::optional<dimension_size_type> size)
+      {
+        tile_size_y = size;
+      }
+
+
+      boost::optional<dimension_size_type>
+      FormatWriter::getTileSizeY() const
+      {
+        return tile_size_y;
+      }
+
+      dimension_size_type
+      FormatWriter::getEffectiveTileSizeX() const
+      {
+        if (!tile_size_x)
+          {
+            return metadataRetrieve->getPixelsSizeX(getSeries());
+          }
+        return *tile_size_x;
+      }
+
+      dimension_size_type
+      FormatWriter::getEffectiveTileSizeY() const
+      {
+        if (!tile_size_y)
+          {
+            return metadataRetrieve->getPixelsSizeY(getSeries());
+          }
+        return *tile_size_y;
       }
 
     }

--- a/lib/ome/files/detail/FormatWriter.cpp
+++ b/lib/ome/files/detail/FormatWriter.cpp
@@ -558,7 +558,15 @@ namespace ome
       {
         if (!tile_size_x)
           {
-            return metadataRetrieve->getPixelsSizeX(getSeries());
+            if (!metadataRetrieve)
+              // fallback before setId and setMetadataRetrieve
+              throw std::logic_error("MetadataStore can not be null");
+            if (currentId)
+              // after setId
+              return metadataRetrieve->getPixelsSizeX(getSeries());
+            else
+              // fallback before setId
+              return metadataRetrieve->getPixelsSizeX(0);
           }
         return *tile_size_x;
       }
@@ -576,7 +584,15 @@ namespace ome
       {
         if (!tile_size_y)
           {
-            return metadataRetrieve->getPixelsSizeY(getSeries());
+            if (!metadataRetrieve)
+              // fallback before setId and setMetadataRetrieve
+              throw std::logic_error("MetadataStore can not be null");
+            if (currentId)
+              // after setId
+              return metadataRetrieve->getPixelsSizeY(getSeries());
+            else
+              // fallback before setId
+              return metadataRetrieve->getPixelsSizeX(0);
           }
         return *tile_size_y;
       }

--- a/lib/ome/files/detail/FormatWriter.cpp
+++ b/lib/ome/files/detail/FormatWriter.cpp
@@ -546,33 +546,15 @@ namespace ome
         return writerProperties.stacks;
       }
 
-      void
+      dimension_size_type
       FormatWriter::setTileSizeX(boost::optional<dimension_size_type> size)
       {
         tile_size_x = size;
-      }
-
-      boost::optional<dimension_size_type>
-      FormatWriter::getTileSizeX() const
-      {
-        return tile_size_x;
-      }
-
-      void
-      FormatWriter::setTileSizeY(boost::optional<dimension_size_type> size)
-      {
-        tile_size_y = size;
-      }
-
-
-      boost::optional<dimension_size_type>
-      FormatWriter::getTileSizeY() const
-      {
-        return tile_size_y;
+        return getTileSizeX();
       }
 
       dimension_size_type
-      FormatWriter::getEffectiveTileSizeX() const
+      FormatWriter::getTileSizeX() const
       {
         if (!tile_size_x)
           {
@@ -582,7 +564,15 @@ namespace ome
       }
 
       dimension_size_type
-      FormatWriter::getEffectiveTileSizeY() const
+      FormatWriter::setTileSizeY(boost::optional<dimension_size_type> size)
+      {
+        tile_size_y = size;
+        return getTileSizeY();
+      }
+
+
+      dimension_size_type
+      FormatWriter::getTileSizeY() const
       {
         if (!tile_size_y)
           {

--- a/lib/ome/files/detail/FormatWriter.h
+++ b/lib/ome/files/detail/FormatWriter.h
@@ -454,28 +454,20 @@ namespace ome
         getCompressionSuffixes() const;
 
         // Documented in superclass.
-        void
+        dimension_size_type
         setTileSizeX(boost::optional<dimension_size_type> size);
 
         // Documented in superclass.
-        boost::optional<dimension_size_type>
+        dimension_size_type
         getTileSizeX() const;
 
         // Documented in superclass.
-        void
+        dimension_size_type
         setTileSizeY(boost::optional<dimension_size_type> size);
 
         // Documented in superclass.
-        boost::optional<dimension_size_type>
+        dimension_size_type
         getTileSizeY() const;
-
-        // Documented in superclass.
-        dimension_size_type
-        getEffectiveTileSizeX() const;
-
-        // Documented in superclass.
-        dimension_size_type
-        getEffectiveTileSizeY() const;
       };
 
     }

--- a/lib/ome/files/detail/FormatWriter.h
+++ b/lib/ome/files/detail/FormatWriter.h
@@ -136,6 +136,12 @@ namespace ome
         /// The frames per second to use when writing.
         frame_rate_type framesPerSecond;
 
+        /// Tile size X.
+        boost::optional<dimension_size_type> tile_size_x;
+
+        /// Tile size Y.
+        boost::optional<dimension_size_type> tile_size_y;
+
         /**
          * Current metadata store. Should never be accessed directly as the
          * semantics of getMetadataRetrieve() prevent "null" access.
@@ -446,6 +452,30 @@ namespace ome
         // Documented in superclass.
         const std::vector<boost::filesystem::path>&
         getCompressionSuffixes() const;
+
+        // Documented in superclass.
+        void
+        setTileSizeX(boost::optional<dimension_size_type> size);
+
+        // Documented in superclass.
+        boost::optional<dimension_size_type>
+        getTileSizeX() const;
+
+        // Documented in superclass.
+        void
+        setTileSizeY(boost::optional<dimension_size_type> size);
+
+        // Documented in superclass.
+        boost::optional<dimension_size_type>
+        getTileSizeY() const;
+
+        // Documented in superclass.
+        dimension_size_type
+        getEffectiveTileSizeX() const;
+
+        // Documented in superclass.
+        dimension_size_type
+        getEffectiveTileSizeY() const;
       };
 
     }

--- a/lib/ome/files/out/MinimalTIFFWriter.cpp
+++ b/lib/ome/files/out/MinimalTIFFWriter.cpp
@@ -237,14 +237,15 @@ namespace ome
         ifd->setImageWidth(getSizeX());
         ifd->setImageHeight(getSizeY());
 
-        // Default strip size.  We base this upon a default
+        // Default strip or tile size.  We base this upon a default
         // chunk size of 64KiB for greyscale images, which will
-        // increase to 192KiB for 3 sample RGB images.
+        // increase to 192KiB for 3 sample RGB images.  We use strips
+        // up to a width of 2048 after which tiles are used.
         if(getSizeX() == 0)
           {
             throw FormatException("Can't set strip or tile size: SizeX is 0");
           }
-        else
+        else if(getSizeX() < 2048)
           {
             // Default to strips, mainly for compatibility with
             // readers which don't support tiles.
@@ -254,6 +255,13 @@ namespace ome
             if (height == 0)
               height = 1;
             ifd->setTileHeight(height);
+          }
+        else
+          {
+            // Default to tiles.
+            ifd->setTileType(tiff::TILE);
+            ifd->setTileWidth(256U);
+            ifd->setTileHeight(256U);
           }
 
         std::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());

--- a/lib/ome/files/out/MinimalTIFFWriter.cpp
+++ b/lib/ome/files/out/MinimalTIFFWriter.cpp
@@ -223,14 +223,14 @@ namespace ome
       }
 
       dimension_size_type
-      MinimalTIFFWriter::getEffectiveTileSizeX() const
+      MinimalTIFFWriter::getTileSizeX() const
       {
         // Get current IFD.
         return ifd->getTileWidth();
       }
 
       dimension_size_type
-      MinimalTIFFWriter::getEffectiveTileSizeY() const
+      MinimalTIFFWriter::getTileSizeY() const
       {
         // Get current IFD.
         return ifd->getTileHeight();
@@ -250,9 +250,6 @@ namespace ome
         ifd->setImageWidth(getSizeX());
         ifd->setImageHeight(getSizeY());
 
-        auto tile_x = getTileSizeX();
-        auto tile_y = getTileSizeY();
-
         // Default strip or tile size.  We base this upon a default
         // chunk size of 64KiB for greyscale images, which will
         // increase to 192KiB for 3 sample RGB images.  We use strips
@@ -261,19 +258,19 @@ namespace ome
           {
             throw FormatException("Can't set strip or tile size: SizeX is 0");
           }
-        else if(!tile_x && tile_y)
+        else if(!this->tile_size_x && this->tile_size_y)
           {
             // Manually set strip size.
             ifd->setTileType(tiff::STRIP);
             ifd->setTileWidth(getSizeX());
-            ifd->setTileHeight(*tile_y);
+            ifd->setTileHeight(*this->tile_size_y);
           }
-        else if(tile_x && tile_y)
+        else if(this->tile_size_x && this->tile_size_y)
           {
             // Manually set tile size.
             ifd->setTileType(tiff::TILE);
-            ifd->setTileWidth(*tile_x);
-            ifd->setTileHeight(*tile_y);
+            ifd->setTileWidth(*this->tile_size_x);
+            ifd->setTileHeight(*this->tile_size_y);
           }
         else if(getSizeX() < 2048)
           {

--- a/lib/ome/files/out/MinimalTIFFWriter.cpp
+++ b/lib/ome/files/out/MinimalTIFFWriter.cpp
@@ -225,15 +225,25 @@ namespace ome
       dimension_size_type
       MinimalTIFFWriter::getTileSizeX() const
       {
-        // Get current IFD.
-        return ifd->getTileWidth();
+        // Get current IFD.  Also requires unset size (fallback) or
+        // nonzero set size.
+        if (currentId && ifd && (!this->tile_size_x ||
+                    (this->tile_size_x && *this->tile_size_x)))
+          return ifd->getTileWidth();
+        else // setId not called yet; fall back.
+          return detail::FormatWriter::getTileSizeX();
       }
 
       dimension_size_type
       MinimalTIFFWriter::getTileSizeY() const
       {
-        // Get current IFD.
-        return ifd->getTileHeight();
+        // Get current IFD.  Also requires unset size (fallback) or
+        // nonzero set size.
+        if (currentId && ifd && (!this->tile_size_y ||
+                    (this->tile_size_y && *this->tile_size_y)))
+          return ifd->getTileHeight();
+        else // setId not called yet; fall back.
+          return detail::FormatWriter::getTileSizeY();
       }
 
       void
@@ -260,17 +270,39 @@ namespace ome
           }
         else if(!this->tile_size_x && this->tile_size_y)
           {
-            // Manually set strip size.
-            ifd->setTileType(tiff::STRIP);
-            ifd->setTileWidth(getSizeX());
-            ifd->setTileHeight(*this->tile_size_y);
+            // Manually set strip size if the size is positive.  Or
+            // else set strips of size 1 as a fallback for
+            // compatibility with Bio-Formats.
+            if(*this->tile_size_y)
+              {
+                ifd->setTileType(tiff::STRIP);
+                ifd->setTileWidth(getSizeX());
+                ifd->setTileHeight(*this->tile_size_y);
+              }
+            else
+              {
+                ifd->setTileType(tiff::STRIP);
+                ifd->setTileWidth(getSizeX());
+                ifd->setTileHeight(1U);
+              }
           }
         else if(this->tile_size_x && this->tile_size_y)
           {
-            // Manually set tile size.
-            ifd->setTileType(tiff::TILE);
-            ifd->setTileWidth(*this->tile_size_x);
-            ifd->setTileHeight(*this->tile_size_y);
+            // Manually set tile size if both sizes are positive.  Or
+            // else set strips of size 1 as a fallback for
+            // compatibility with Bio-Formats.
+            if(*this->tile_size_x && *this->tile_size_y)
+              {
+                ifd->setTileType(tiff::TILE);
+                ifd->setTileWidth(*this->tile_size_x);
+                ifd->setTileHeight(*this->tile_size_y);
+              }
+            else
+              {
+                ifd->setTileType(tiff::STRIP);
+                ifd->setTileWidth(getSizeX());
+                ifd->setTileHeight(1U);
+              }
           }
         else if(getSizeX() < 2048)
           {

--- a/lib/ome/files/out/MinimalTIFFWriter.h
+++ b/lib/ome/files/out/MinimalTIFFWriter.h
@@ -116,6 +116,14 @@ namespace ome
         void
         setPlane(dimension_size_type plane) const;
 
+        // Documented in superclass.
+        dimension_size_type
+        getEffectiveTileSizeX() const;
+
+        // Documented in superclass.
+        dimension_size_type
+        getEffectiveTileSizeY() const;
+
       protected:
         /// Flush current IFD and create new IFD.
         void

--- a/lib/ome/files/out/MinimalTIFFWriter.h
+++ b/lib/ome/files/out/MinimalTIFFWriter.h
@@ -118,11 +118,11 @@ namespace ome
 
         // Documented in superclass.
         dimension_size_type
-        getEffectiveTileSizeX() const;
+        getTileSizeX() const;
 
         // Documented in superclass.
         dimension_size_type
-        getEffectiveTileSizeY() const;
+        getTileSizeY() const;
 
       protected:
         /// Flush current IFD and create new IFD.

--- a/lib/ome/files/out/OMETIFFWriter.cpp
+++ b/lib/ome/files/out/OMETIFFWriter.cpp
@@ -617,7 +617,7 @@ namespace ome
       }
 
       dimension_size_type
-      OMETIFFWriter::getEffectiveTileSizeX() const
+      OMETIFFWriter::getTileSizeX() const
       {
         // Get current IFD.
         std::shared_ptr<tiff::IFD> ifd (currentTIFF->second.tiff->getCurrentDirectory());
@@ -625,7 +625,7 @@ namespace ome
       }
 
       dimension_size_type
-      OMETIFFWriter::getEffectiveTileSizeY() const
+      OMETIFFWriter::getTileSizeY() const
       {
         // Get current IFD.
         std::shared_ptr<tiff::IFD> ifd (currentTIFF->second.tiff->getCurrentDirectory());
@@ -648,9 +648,6 @@ namespace ome
         ifd->setImageWidth(getSizeX());
         ifd->setImageHeight(getSizeY());
 
-        auto tile_x = getTileSizeX();
-        auto tile_y = getTileSizeY();
-
         // Default strip or tile size.  We base this upon a default
         // chunk size of 64KiB for greyscale images, which will
         // increase to 192KiB for 3 sample RGB images.  We use strips
@@ -659,19 +656,19 @@ namespace ome
           {
             throw FormatException("Can't set strip or tile size: SizeX is 0");
           }
-        else if(!tile_x && tile_y)
+        else if(!this->tile_size_x && this->tile_size_y)
           {
             // Manually set strip size.
             ifd->setTileType(tiff::STRIP);
             ifd->setTileWidth(getSizeX());
-            ifd->setTileHeight(*tile_y);
+            ifd->setTileHeight(*this->tile_size_y);
           }
-        else if(tile_x && tile_y)
+        else if(this->tile_size_x && this->tile_size_y)
           {
             // Manually set tile size.
             ifd->setTileType(tiff::TILE);
-            ifd->setTileWidth(*tile_x);
-            ifd->setTileHeight(*tile_y);
+            ifd->setTileWidth(*this->tile_size_x);
+            ifd->setTileHeight(*this->tile_size_y);
           }
         else if(getSizeX() < 2048)
           {

--- a/lib/ome/files/out/OMETIFFWriter.cpp
+++ b/lib/ome/files/out/OMETIFFWriter.cpp
@@ -633,14 +633,15 @@ namespace ome
         ifd->setImageWidth(getSizeX());
         ifd->setImageHeight(getSizeY());
 
-        // Default strip size.  We base this upon a default
+        // Default strip or tile size.  We base this upon a default
         // chunk size of 64KiB for greyscale images, which will
-        // increase to 192KiB for 3 sample RGB images.
+        // increase to 192KiB for 3 sample RGB images.  We use strips
+        // up to a width of 2048 after which tiles are used.
         if(getSizeX() == 0)
           {
             throw FormatException("Can't set strip or tile size: SizeX is 0");
           }
-        else
+        else if(getSizeX() < 2048)
           {
             // Default to strips, mainly for compatibility with
             // readers which don't support tiles.
@@ -650,6 +651,13 @@ namespace ome
             if (height == 0)
               height = 1;
             ifd->setTileHeight(height);
+          }
+        else
+          {
+            // Default to tiles.
+            ifd->setTileType(tiff::TILE);
+            ifd->setTileWidth(256U);
+            ifd->setTileHeight(256U);
           }
 
         std::array<dimension_size_type, 3> coords = getZCTCoords(getPlane());

--- a/lib/ome/files/out/OMETIFFWriter.h
+++ b/lib/ome/files/out/OMETIFFWriter.h
@@ -173,6 +173,14 @@ namespace ome
         void
         setPlane(dimension_size_type plane) const;
 
+        // Documented in superclass.
+        dimension_size_type
+        getEffectiveTileSizeX() const;
+
+        // Documented in superclass.
+        dimension_size_type
+        getEffectiveTileSizeY() const;
+
       protected:
         /// Flush current IFD and create new IFD.
         void

--- a/lib/ome/files/out/OMETIFFWriter.h
+++ b/lib/ome/files/out/OMETIFFWriter.h
@@ -175,11 +175,11 @@ namespace ome
 
         // Documented in superclass.
         dimension_size_type
-        getEffectiveTileSizeX() const;
+        getTileSizeX() const;
 
         // Documented in superclass.
         dimension_size_type
-        getEffectiveTileSizeY() const;
+        getTileSizeY() const;
 
       protected:
         /// Flush current IFD and create new IFD.

--- a/test/ome-files/data/CMakeLists.txt
+++ b/test/ome-files/data/CMakeLists.txt
@@ -91,6 +91,16 @@ if(GRAPHICSMAGICK_EXECUTABLE)
                                      "${genpng}")
           list(APPEND images "${genpng}")
 
+          # Generate TIFF without explicit tiling information
+          set(gentiff "${CMAKE_CURRENT_BINARY_DIR}/${image}-${imagewidth}x${imageheight}-${planarconfig}.tiff")
+          add_custom_command(OUTPUT "${gentiff}"
+                             DEPENDS "${genpng}"
+                             COMMAND "${GRAPHICSMAGICK_EXECUTABLE}" convert
+                             "${genpng}"
+                             -interlace "${interlace}"
+                             "${gentiff}")
+          list(APPEND images "${gentiff}")
+
           # Generate TIFF tile variants for each image size
           foreach(tilewidth 16 32 48 64)
             foreach(tileheight 16 32 48 64)

--- a/test/ome-files/minimaltiffwriter.cpp
+++ b/test/ome-files/minimaltiffwriter.cpp
@@ -147,6 +147,8 @@ TEST(TIFFWriter, SupportedCompressionTypes)
 
 TEST_P(TIFFWriterTest, setId)
 {
+  const TIFFTestParameters& params = GetParam();
+
   std::vector<std::shared_ptr<CoreMetadata>> seriesList;
   for (const auto& i : *tiff)
     {
@@ -163,6 +165,11 @@ TEST_P(TIFFWriterTest, setId)
   bool interleaved = true;
 
   tiffwriter.setInterleaved(interleaved);
+  if(params.tile)
+    {
+      tiffwriter.setTileSizeX(params.tilewidth);
+      tiffwriter.setTileSizeY(params.tilelength);
+    }
 
   ASSERT_NO_THROW(tiffwriter.setId(testfile));
 

--- a/test/ome-files/ometiffwriter.cpp
+++ b/test/ome-files/ometiffwriter.cpp
@@ -108,6 +108,8 @@ public:
 
 TEST_P(TIFFWriterTest, setId)
 {
+  const TIFFTestParameters& params = GetParam();
+
   std::vector<std::shared_ptr<CoreMetadata>> seriesList;
   for (const auto& i : *tiff)
     {
@@ -125,6 +127,8 @@ TEST_P(TIFFWriterTest, setId)
 
   tiffwriter.setInterleaved(interleaved);
   tiffwriter.setCompression("Deflate");
+  tiffwriter.setTileSizeX(params.tilewidth);
+  tiffwriter.setTileSizeY(params.tilelength);
 
   ASSERT_NO_THROW(tiffwriter.setId(testfile));
 

--- a/test/ome-files/ometiffwriter.cpp
+++ b/test/ome-files/ometiffwriter.cpp
@@ -42,6 +42,7 @@
 #include <ome/files/CoreMetadata.h>
 #include <ome/files/MetadataTools.h>
 #include <ome/files/VariantPixelBuffer.h>
+#include <ome/files/in/OMETIFFReader.h>
 #include <ome/files/out/OMETIFFWriter.h>
 #include <ome/files/tiff/Field.h>
 #include <ome/files/tiff/IFD.h>
@@ -58,6 +59,7 @@
 using ome::files::dimension_size_type;
 using ome::files::CoreMetadata;
 using ome::files::VariantPixelBuffer;
+using ome::files::in::OMETIFFReader;
 using ome::files::out::OMETIFFWriter;
 using ome::files::tiff::IFD;
 using ome::files::tiff::TIFF;
@@ -123,9 +125,7 @@ TEST_P(TIFFWriterTest, setId)
 
   tiffwriter.setMetadataRetrieve(retrieve);
 
-  bool interleaved = true;
-
-  tiffwriter.setInterleaved(interleaved);
+  tiffwriter.setInterleaved(!params.imageplanar);
   tiffwriter.setCompression("Deflate");
   tiffwriter.setTileSizeX(params.tilewidth);
   tiffwriter.setTileSizeY(params.tilelength);
@@ -148,7 +148,7 @@ TEST_P(TIFFWriterTest, setId)
       shape[ome::files::DIM_SPATIAL_Z] = shape[ome::files::DIM_TEMPORAL_T] = shape[ome::files::DIM_CHANNEL] =
         shape[ome::files::DIM_MODULO_Z] = shape[ome::files::DIM_MODULO_T] = shape[ome::files::DIM_MODULO_C] = 1;
 
-      ome::files::PixelBufferBase::storage_order_type order(ome::files::PixelBufferBase::make_storage_order(ome::xml::model::enums::DimensionOrder::XYZTC, interleaved));
+      ome::files::PixelBufferBase::storage_order_type order(ome::files::PixelBufferBase::make_storage_order(ome::xml::model::enums::DimensionOrder::XYZTC, !params.imageplanar));
 
       VariantPixelBuffer src(shape, ifd->getPixelType(), order);
       src = buf;
@@ -158,6 +158,47 @@ TEST_P(TIFFWriterTest, setId)
       ++currentSeries;
     }
   tiffwriter.close();
+
+  // Read and validate OME-TIFF
+  {
+    OMETIFFReader tiffreader;
+    std::shared_ptr<ome::xml::meta::MetadataStore> store(std::make_shared<ome::xml::meta::OMEXMLMetadata>());
+    ASSERT_NO_THROW(tiffreader.setMetadataStore(store));
+
+    ASSERT_NO_THROW(tiffreader.setId(testfile));
+
+    ASSERT_EQ(seriesList.size(), tiffreader.getSeriesCount());
+    for(dimension_size_type i = 0; i < tiffreader.getSeriesCount(); ++i)
+      {
+        tiffreader.setSeries(i);
+        const std::shared_ptr<CoreMetadata> ref = seriesList.at(i);
+        
+        EXPECT_EQ(ref->sizeX, tiffreader.getSizeX());
+        EXPECT_EQ(ref->sizeY, tiffreader.getSizeY());
+        EXPECT_EQ(ref->sizeZ, tiffreader.getSizeZ());
+        EXPECT_EQ(ref->sizeT, tiffreader.getSizeT());
+        EXPECT_EQ(ref->sizeC.size(), tiffreader.getEffectiveSizeC());
+        if (params.tilewidth)
+          EXPECT_EQ(*params.tilewidth, tiffreader.getOptimalTileWidth(0));
+        if (params.tilelength)
+          EXPECT_EQ(*params.tilelength, tiffreader.getOptimalTileHeight(0));
+        EXPECT_EQ(ome::xml::model::enums::PixelType::UINT8, tiffreader.getPixelType());
+        EXPECT_EQ(8, tiffreader.getBitsPerPixel());
+        EXPECT_EQ(3, tiffreader.getRGBChannelCount(0));
+        EXPECT_EQ(!params.imageplanar, tiffreader.isInterleaved());
+
+        VariantPixelBuffer buf;
+        std::shared_ptr<IFD> ifd = tiff->getDirectoryByIndex(i);
+        ASSERT_TRUE(static_cast<bool>(ifd));
+        ifd->readImage(buf);
+
+        VariantPixelBuffer vb;
+        tiffreader.openBytes(0, vb);
+
+        EXPECT_TRUE(buf == vb);
+      }
+  }
+
 }
 
 std::vector<TIFFTestParameters> params(find_tiff_tests());

--- a/test/ome-files/tiff.cpp
+++ b/test/ome-files/tiff.cpp
@@ -1033,15 +1033,19 @@ TEST_P(TIFFVariantTest, TileInfo)
   const TIFFTestParameters& params = GetParam();
   TileInfo info = ifd->getTileInfo();
 
-  EXPECT_EQ(params.tilewidth, info.tileWidth());
-  EXPECT_EQ(params.tilelength, info.tileHeight());
+  if (params.tilewidth)
+    EXPECT_EQ(*params.tilewidth, info.tileWidth());
+  if (params.tilelength)
+    EXPECT_EQ(*params.tilelength, info.tileHeight());
   EXPECT_NE(0U, info.bufferSize());
 
-  dimension_size_type ecol = iwidth / params.tilewidth;
-  if (iwidth % params.tilewidth)
+  dimension_size_type ecol = iwidth /
+    (params.tilewidth ? *params.tilewidth : params.imagewidth);
+  if (iwidth % (params.tilewidth ? *params.tilewidth : params.imagewidth))
     ++ecol;
-  dimension_size_type erow = iheight / params.tilelength;
-  if (iheight % params.tilelength)
+  dimension_size_type erow = iheight /
+    (params.tilelength ? *params.tilelength : params.imagelength);
+  if (iheight % (params.tilelength ? *params.tilelength : params.imagelength))
     ++erow;
   EXPECT_EQ(erow, info.tileRowCount());
   EXPECT_EQ(ecol, info.tileColumnCount());
@@ -1052,7 +1056,9 @@ TEST_P(TIFFVariantTest, TileInfo)
     ASSERT_EQ(ome::files::tiff::CONTIG, planarconfig);
 
   if (params.tile)
-    ASSERT_EQ(ome::files::tiff::TILE, info.tileType());
+    ASSERT_EQ(*params.tile, info.tileType());
+  else
+    ASSERT_EQ(ome::files::tiff::STRIP, info.tileType());
 }
 
 // Check that the first tile matches the expected tile size
@@ -1066,21 +1072,23 @@ TEST_P(TIFFVariantTest, TilePlaneRegion0)
   PlaneRegion region0 = info.tileRegion(0, full);
   EXPECT_EQ(0U, region0.x);
   EXPECT_EQ(0U, region0.y);
-  if (params.imagewidth < params.tilewidth)
+  if (!params.tilewidth ||
+      params.imagewidth < *params.tilewidth)
     {
       EXPECT_EQ(params.imagewidth, region0.w);
     }
   else
     {
-      EXPECT_EQ(params.tilewidth, region0.w);
+      EXPECT_EQ(*params.tilewidth, region0.w);
     }
-  if (params.imagelength < params.tilelength)
+  if (!params.tilelength ||
+      params.imagelength < *params.tilelength)
     {
       EXPECT_EQ(params.imagelength, region0.h);
     }
   else
     {
-      EXPECT_EQ(params.tilelength, region0.h);
+      EXPECT_EQ(*params.tilelength, region0.h);
     }
 }
 

--- a/test/ome-files/tiffsamples.h
+++ b/test/ome-files/tiffsamples.h
@@ -40,6 +40,7 @@
 #define TEST_TIFFSAMPLES_H
 
 #include <boost/filesystem.hpp>
+#include <boost/optional.hpp>
 
 #include <ome/files/Types.h>
 #include <ome/files/tiff/Types.h>
@@ -53,14 +54,14 @@
 
 struct TIFFTestParameters
 {
-  bool tile;
+  boost::optional<ome::files::tiff::TileType> tile;
   std::string file;
   std::string wfile;
   bool imageplanar;
   ome::files::dimension_size_type imagewidth;
   ome::files::dimension_size_type imagelength;
-  ome::files::dimension_size_type tilewidth;
-  ome::files::dimension_size_type tilelength;
+  boost::optional<ome::files::dimension_size_type> tilewidth;
+  boost::optional<ome::files::dimension_size_type> tilelength;
   ome::files::tiff::Compression compression;
 };
 
@@ -69,13 +70,23 @@ inline std::basic_ostream<charT,traits>&
 operator<< (std::basic_ostream<charT,traits>& os,
             const TIFFTestParameters& p)
 {
-  return os << p.file << " [" << p.wfile << "] ("
-            << p.imagewidth << "x" << p.imagelength
-            << (p.imageplanar ? " planar" : " chunky")
-            << (p.tile ? " tiled " : " strips ")
-            << p.tilewidth << "x" << p.tilelength
-            << " compression " << p.compression
-            << ")";
+  os << p.file << " [" << p.wfile << "] ("
+     << p.imagewidth << "x" << p.imagelength
+     << (p.imageplanar ? " planar" : " chunky")
+     << (p.tile ? (*p.tile ? " tiled " : " strips ") : "none");
+  if(p.tilewidth)
+    os << *p.tilewidth;
+  else
+    os << "unknown";
+  os << "x";
+  if(p.tilelength)
+    os << *p.tilelength;
+  else
+    os << "unknown";
+  os << " compression " << p.compression
+     << ")";
+
+  return os;
 }
 
 extern std::vector<TIFFTestParameters>


### PR DESCRIPTION
https://trello.com/c/y1HuXrzQ/17-formatwriter-bio-formats-tiling-api-backport

A little different than the Java API in these respects:

- getters and setters pass `optional<size>` rather than `size`.  This was already used by other settable properties here, and it allows us to detect the "unset by user" case.  This is important to distinguish between strips and tiles at the limits where the tile/strip x size == the image x size
- we don't pass back the set value in the `set` methods as a result
- `getEffectiveTileSize[XY]` allows querying of the reader-specific tile size set in response to the size request.  This can modify the user's intent with reader-specific constraints.

- `MinimalTIFFWriter` and `OMETIFFWriter` updated to implement `getEffectiveTileSize[XY]`; they report back the sizes set on the IFD.
- `setupIFD` in both writers will use the set tile sizes to set up the IFD.  If one or both are unset, it will result in a default strip or tile size being selected.
- Unit tests updated to test tiling behaviour.