### PR TITLE
PixelBuffers: Don't use static_vistors returning references

### DIFF
--- a/lib/ome/files/PixelBuffer.h
+++ b/lib/ome/files/PixelBuffer.h
@@ -829,7 +829,7 @@ namespace ome
 
       /// Find a PixelBuffer data array of a specific pixel type.
       template<typename T>
-      struct PixelBufferArrayVisitor : public boost::static_visitor<typename PixelBuffer<T>::array_ref_type&>
+      struct PixelBufferArrayVisitor : public boost::static_visitor<typename PixelBuffer<T>::array_ref_type *>
       {
         /**
          * PixelBuffer of any type.
@@ -838,18 +838,18 @@ namespace ome
          * @returns a reference to the data array.
          */
         template <typename U>
-        typename PixelBuffer<T>::array_ref_type&
+        typename PixelBuffer<T>::array_ref_type *
         operator() (U& v) const
         {
           if (!v)
             throw std::runtime_error("Null array type");
-          return *v;
+          return v.get();
         }
       };
 
       /// Find a PixelBuffer data array of a specific pixel type.
       template<typename T>
-      struct PixelBufferConstArrayVisitor : public boost::static_visitor<const typename PixelBuffer<T>::array_ref_type&>
+      struct PixelBufferConstArrayVisitor : public boost::static_visitor<const typename PixelBuffer<T>::array_ref_type *>
       {
         /**
          * PixelBuffer of any type.
@@ -858,12 +858,12 @@ namespace ome
          * @returns a const reference to the data array.
          */
         template <typename U>
-        const typename PixelBuffer<T>::array_ref_type&
+        const typename PixelBuffer<T>::array_ref_type *
         operator() (U& v) const
         {
           if (!v)
             throw std::runtime_error("Null array type");
-          return *v;
+          return v.get();
         }
       };
 
@@ -874,7 +874,7 @@ namespace ome
     PixelBuffer<T>::array()
     {
       detail::PixelBufferArrayVisitor<T> v;
-      return boost::apply_visitor(v, multiarray);
+      return *(boost::apply_visitor(v, multiarray));
     }
 
     template<typename T>
@@ -882,7 +882,7 @@ namespace ome
     PixelBuffer<T>::array() const
     {
       detail::PixelBufferConstArrayVisitor<T> v;
-      return boost::apply_visitor(v, multiarray);
+      return *(boost::apply_visitor(v, multiarray));
     }
 
   }

--- a/lib/ome/files/VariantPixelBuffer.cpp
+++ b/lib/ome/files/VariantPixelBuffer.cpp
@@ -150,15 +150,15 @@ namespace
     }
   };
 
-  struct PBStorageOrderVisitor : public boost::static_visitor<const VariantPixelBuffer::storage_order_type&>
+  struct PBStorageOrderVisitor : public boost::static_visitor<const VariantPixelBuffer::storage_order_type *>
   {
     template <typename T>
-    const VariantPixelBuffer::storage_order_type&
+    const VariantPixelBuffer::storage_order_type *
     operator() (const T& v)
     {
       if (!v)
         throw std::runtime_error("Null pixel type");
-      return v->storage_order();
+      return &(v->storage_order());
     }
   };
 
@@ -375,7 +375,7 @@ namespace ome
     VariantPixelBuffer::storage_order() const
     {
       PBStorageOrderVisitor v;
-      return boost::apply_visitor(v, buffer);
+      return *(boost::apply_visitor(v, buffer));
     }
 
     PixelType

--- a/lib/ome/files/VariantPixelBuffer.h
+++ b/lib/ome/files/VariantPixelBuffer.h
@@ -649,7 +649,7 @@ namespace ome
 
       /// Find a PixelBuffer data array of a specific pixel type.
       template<typename T>
-      struct VariantPixelBufferVisitor : public boost::static_visitor<PixelBuffer<T>&>
+      struct VariantPixelBufferVisitor : public boost::static_visitor<PixelBuffer<T> *>
       {
         /**
          * PixelBuffer of correct type.
@@ -658,12 +658,12 @@ namespace ome
          * @returns a pointer to the data array.
          * @throws if the PixelBuffer is null.
          */
-        PixelBuffer<T>&
+        PixelBuffer<T> *
         operator() (std::shared_ptr<PixelBuffer<T>>& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");
-          return *v;
+          return v.get();
         }
 
         /**
@@ -673,7 +673,7 @@ namespace ome
          * @returns a pointer to the data array.
          */
         template <typename U>
-        PixelBuffer<T>&
+        PixelBuffer<T> *
         operator() (U& /* v */) const
         {
           throw std::runtime_error("Unsupported pixel type conversion for buffer");
@@ -682,7 +682,7 @@ namespace ome
 
       /// Find a PixelBuffer data array of a specific pixel type.
       template<typename T>
-      struct VariantPixelBufferConstVisitor : public boost::static_visitor<const PixelBuffer<T>&>
+      struct VariantPixelBufferConstVisitor : public boost::static_visitor<const PixelBuffer<T> *>
       {
         /**
          * PixelBuffer of correct type.
@@ -691,12 +691,12 @@ namespace ome
          * @returns a pointer to the data array.
          * @throws if the PixelBuffer is null.
          */
-        const PixelBuffer<T>&
+        const PixelBuffer<T> *
         operator() (const std::shared_ptr<PixelBuffer<T>>& v) const
         {
           if (!v)
             throw std::runtime_error("Null pixel type");
-          return *v;
+          return v.get();
         }
 
         /**
@@ -706,7 +706,7 @@ namespace ome
          * @returns a pointer to the data array.
          */
         template <typename U>
-        const PixelBuffer<T>&
+        const PixelBuffer<T> *
         operator() (U& /* v */) const
         {
           throw std::runtime_error("Unsupported pixel type conversion for buffer");
@@ -919,7 +919,7 @@ namespace ome
     VariantPixelBuffer::array()
     {
       detail::VariantPixelBufferVisitor<T> v;
-      return boost::apply_visitor(v, buffer).array();
+      return boost::apply_visitor(v, buffer)->array();
     }
 
     /// @copydoc VariantPixelBuffer::array() const
@@ -928,7 +928,7 @@ namespace ome
     VariantPixelBuffer::array() const
     {
       detail::VariantPixelBufferConstVisitor<T> v;
-      return boost::apply_visitor(v, buffer).array();
+      return boost::apply_visitor(v, buffer)->array();
     }
 
     template<typename T>
@@ -936,7 +936,7 @@ namespace ome
     VariantPixelBuffer::data()
     {
       detail::VariantPixelBufferVisitor<T> v;
-      return boost::apply_visitor(v, buffer).data();
+      return boost::apply_visitor(v, buffer)->data();
     }
 
     template<typename T>
@@ -944,7 +944,7 @@ namespace ome
     VariantPixelBuffer::data() const
     {
       detail::VariantPixelBufferConstVisitor<T> v;
-      return boost::apply_visitor(v, buffer).data();
+      return boost::apply_visitor(v, buffer)->data();
     }
 
     template<typename T>
@@ -952,7 +952,7 @@ namespace ome
     VariantPixelBuffer::origin() const
     {
       detail::VariantPixelBufferConstVisitor<T> v;
-      return boost::apply_visitor(v, buffer).origin();
+      return boost::apply_visitor(v, buffer)->origin();
     }
 
     /**


### PR DESCRIPTION
See [trac ticket](https://svn.boost.org/trac/boost/ticket/11251).  This is a workaround for a bug in Boost 1.58, as provided by Ubuntu 16.04.

Testing: should build fine on the existing CI nodes.  This will make the build also work on Ubuntu 16.04; should go green (well, blue) on the test Ubuntu 16.04 CI node.

Getting this into the next milestone would be useful.  Firstly for the benefit of users on the current Ubuntu LTS release, and secondly to allow testing and subsequent deployment of the new CI infrastructure.

Testing: check job status.  There are no functional changes.