### PR TITLE
Update API reference including use of deleted methods

### DIFF
--- a/lib/ome/files/FormatHandler.h
+++ b/lib/ome/files/FormatHandler.h
@@ -67,13 +67,12 @@ namespace ome
       FormatHandler()
       {}
 
-    private:
-      /// Copy constructor (deleted).
-      FormatHandler (const FormatHandler&);
+      /// @cond SKIP
+      FormatHandler (const FormatHandler&) = delete;
 
-      /// Assignment operator (deleted).
       FormatHandler&
-      operator= (const FormatHandler&);
+      operator= (const FormatHandler&) = delete;
+      /// @endcond SKIP
 
     public:
       /// Destructor.

--- a/lib/ome/files/FormatReader.h
+++ b/lib/ome/files/FormatReader.h
@@ -143,13 +143,12 @@ namespace ome
       FormatReader()
       {}
 
-    private:
-      /// Copy constructor (deleted).
-      FormatReader (const FormatReader&);
+      /// @cond SKIP
+      FormatReader (const FormatReader&) = delete;
 
-      /// Assignment operator (deleted).
       FormatReader&
-      operator= (const FormatReader&);
+      operator= (const FormatReader&) = delete;
+      /// @endcond SKIP
 
     public:
       /// Destructor.
@@ -678,6 +677,8 @@ namespace ome
       /**
        * Specifies whether or not to save proprietary metadata
        * in the MetadataStore.
+       *
+       * @param populate @c true to save or @c false to discard.
        */
       virtual
       void

--- a/lib/ome/files/FormatWriter.h
+++ b/lib/ome/files/FormatWriter.h
@@ -90,13 +90,12 @@ namespace ome
       FormatWriter()
       {}
 
-    private:
-      /// Copy constructor (deleted).
-      FormatWriter (const FormatWriter&);
+      /// @cond SKIP
+      FormatWriter (const FormatWriter&) = delete;
 
-      /// Assignment operator (deleted).
       FormatWriter&
-      operator= (const FormatWriter&);
+      operator= (const FormatWriter&) = delete;
+      /// @endcond SKIP
 
     public:
       /// Destructor.
@@ -400,7 +399,8 @@ namespace ome
        * underlying file format.  Call getTileSizeX() to get the
        * effective size in use by the writer, or use the return value.
        *
-       * @param size the effective tile width.
+       * @param size the requested tile width.
+       * @returns the effective tile width.
        **/
       virtual
       dimension_size_type
@@ -429,7 +429,8 @@ namespace ome
        * underlying file format.  Call getTileSizeY() to get the
        * effective size in use by the writer, or use the return value.
        *
-       * @param size the effective tile height.
+       * @param size the requested tile height.
+       * @returns the effective tile height.
        **/
       virtual
       dimension_size_type

--- a/lib/ome/files/FormatWriter.h
+++ b/lib/ome/files/FormatWriter.h
@@ -396,8 +396,11 @@ namespace ome
        * Set the requested tile width.
        *
        * The requested tile width may not be supported by the
-       * underlying file format.  Call getTileSizeX() to get the
-       * effective size in use by the writer, or use the return value.
+       * underlying file format.  If the width requested is
+       * unsupported, the writer may set the nearest supported size,
+       * or the full image width or greater if no smaller tile sizes
+       * are supported.  Call getTileSizeX() to get the effective size
+       * in use by the writer, or use the return value.
        *
        * @param size the requested tile width.
        * @returns the effective tile width.
@@ -409,12 +412,7 @@ namespace ome
       /**
        * Get the effective tile width.
        *
-       * This is intended for use with saveBytes().  Unlike
-       * getTileSizeX(), which returns the size set by the caller (if
-       * any), this method returns the size in use by the reader.  If
-       * the width requested is unsupported, the writer may set the
-       * nearest supported size, or the full image width or greater if
-       * no smaller tile sizes are supported.
+       * This is intended for use with saveBytes().
        *
        * @returns the effective tile width.
        **/
@@ -426,8 +424,11 @@ namespace ome
        * Set the requested tile height.
        *
        * The requested tile height may not be supported by the
-       * underlying file format.  Call getTileSizeY() to get the
-       * effective size in use by the writer, or use the return value.
+       * underlying file format.  If the height requested is
+       * unsupported, the writer may set the nearest supported size,
+       * or the full image height or greater if no smaller tile sizes
+       * are supported.  Call getTileSizeY() to get the effective size
+       * in use by the writer, or use the return value.
        *
        * @param size the requested tile height.
        * @returns the effective tile height.
@@ -439,12 +440,7 @@ namespace ome
       /**
        * Get the effective tile height.
        *
-       * This is intended for use with saveBytes().  Unlike
-       * getTileSizeY(), which returns the size set by the caller (if
-       * any), this method returns the size in use by the reader.  If
-       * the height requested is unsupported, the writer may set the
-       * nearest supported size, or the full image height or greater if
-       * no smaller tile sizes are supported.
+       * This is intended for use with saveBytes().
        *
        * @returns the effective tile height.
        **/

--- a/lib/ome/files/PixelBuffer.h
+++ b/lib/ome/files/PixelBuffer.h
@@ -459,6 +459,8 @@ namespace ome
 
       /**
        * Get the number of pixel elements in the multi-dimensional array.
+       *
+       * @returns the number of elements.
        */
       size_type
       num_elements() const
@@ -468,6 +470,8 @@ namespace ome
 
       /**
        * Get the number of dimensions in the multi-dimensional array.
+       *
+       * @returns the number of dimensions.
        */
       size_type
       num_dimensions() const

--- a/lib/ome/files/TileBuffer.h
+++ b/lib/ome/files/TileBuffer.h
@@ -66,18 +66,16 @@ namespace ome
       /// Destructor.
       virtual ~TileBuffer();
 
-    private:
       // To avoid unintentional and expensive copies, copying and
       // assignment of buffers is prevented.
 
-      /// Copy constructor (deleted).
-      TileBuffer (const TileBuffer&);
+      /// @cond SKIP
+      TileBuffer (const TileBuffer&) = delete;
 
-      /// Assignment operator (deleted).
       TileBuffer&
-      operator= (const TileBuffer&);
+      operator= (const TileBuffer&) = delete;
+      /// @endcond SKIP
 
-    public:
       /**
        * Get the buffer size.
        *

--- a/lib/ome/files/TileCache.h
+++ b/lib/ome/files/TileCache.h
@@ -69,18 +69,16 @@ namespace ome
       /// Destructor.
       virtual ~TileCache();
 
-    private:
       // To avoid unintentional and expensive copies, copying and
       // assignment of caches is prevented.
 
-      /// Copy constructor (deleted).
-      TileCache (const TileCache&);
+      /// @cond SKIP
+      TileCache (const TileCache&) = delete;
 
-      /// Assignment operator (deleted).
       TileCache&
-      operator= (const TileCache&);
+      operator= (const TileCache&) = delete;
+      /// @endcond SKIP
 
-    public:
       /**
        * Insert a tile into the tile cache.
        *

--- a/lib/ome/files/VariantPixelBuffer.h
+++ b/lib/ome/files/VariantPixelBuffer.h
@@ -417,12 +417,16 @@ namespace ome
 
       /**
        * Get the number of pixel elements in the multi-dimensional array.
+       *
+       * @returns the number of elements.
        */
       size_type
       num_elements() const;
 
       /**
        * Get the number of dimensions in the multi-dimensional array.
+       *
+       * @returns the number of dimensions.
        */
       size_type
       num_dimensions() const;
@@ -482,12 +486,16 @@ namespace ome
 
       /**
        * Get the type of pixels stored in the buffer.
+       *
+       * @returns the pixel type.
        */
       ::ome::xml::model::enums::PixelType
       pixelType() const;
 
       /**
        * Get the endianness of the pixel type stored in the buffer.
+       *
+       * @returns the endian type.
        */
       EndianType
       endianType() const;
@@ -913,7 +921,7 @@ namespace ome
 
     }
 
-    /// @copydoc VariantPixelBuffer::array()
+    /// @copydoc PixelBuffer::array()
     template<typename T>
     inline typename PixelBuffer<T>::array_ref_type&
     VariantPixelBuffer::array()
@@ -922,7 +930,7 @@ namespace ome
       return boost::apply_visitor(v, buffer)->array();
     }
 
-    /// @copydoc VariantPixelBuffer::array() const
+    /// @copydoc PixelBuffer::array() const
     template<typename T>
     inline const typename PixelBuffer<T>::array_ref_type&
     VariantPixelBuffer::array() const

--- a/lib/ome/files/detail/FormatReader.h
+++ b/lib/ome/files/detail/FormatReader.h
@@ -210,18 +210,17 @@ namespace ome
         /// Constructor.
         FormatReader(const ReaderProperties&);
 
+        /// @cond SKIP
+        FormatReader (const FormatReader&) = delete;
+
+        FormatReader&
+        operator= (const FormatReader&) = delete;
+        /// @endcond SKIP
+
       public:
         /// Destructor.
         virtual
         ~FormatReader();
-
-      private:
-        /// Copy constructor (deleted).
-        FormatReader (const FormatReader&);
-
-        /// Assignment operator (deleted).
-        FormatReader&
-        operator= (const FormatReader&);
 
       protected:
         /**

--- a/lib/ome/files/detail/FormatWriter.h
+++ b/lib/ome/files/detail/FormatWriter.h
@@ -148,17 +148,15 @@ namespace ome
          */
         std::shared_ptr<::ome::xml::meta::MetadataRetrieve> metadataRetrieve;
 
-      protected:
         /// Constructor.
         FormatWriter(const WriterProperties&);
 
-      private:
-        /// Copy constructor (deleted).
-        FormatWriter (const FormatWriter&);
+        /// @cond SKIP
+        FormatWriter (const FormatWriter&) = delete;
 
-        /// Assignment operator (deleted).
         FormatWriter&
-        operator= (const FormatWriter&);
+        operator= (const FormatWriter&) = delete;
+        /// @endcond SKIP
 
       public:
         /// Destructor.

--- a/lib/ome/files/in/MinimalTIFFReader.h
+++ b/lib/ome/files/in/MinimalTIFFReader.h
@@ -79,7 +79,11 @@ namespace ome
         /// Constructor.
         MinimalTIFFReader();
 
-        /// Constructor with reader properties (for derived readers).
+        /**
+         * Constructor with reader properties (for derived readers).
+         *
+         * @param readerProperties the derived reader properties.
+         */
         MinimalTIFFReader(const ome::files::detail::ReaderProperties& readerProperties);
 
         /// Destructor.

--- a/lib/ome/files/out/MinimalTIFFWriter.h
+++ b/lib/ome/files/out/MinimalTIFFWriter.h
@@ -92,7 +92,11 @@ namespace ome
         /// Constructor.
         MinimalTIFFWriter();
 
-        /// Constructor with writer properties (for derived writers).
+        /**
+         * Constructor with writer properties (for derived writers).
+         *
+         * @param writerProperties the derived writer properties.
+         */
         MinimalTIFFWriter(const ome::files::detail::WriterProperties& writerProperties);
 
         /// Destructor.

--- a/lib/ome/files/tiff/Field.h
+++ b/lib/ome/files/tiff/Field.h
@@ -161,6 +161,7 @@ namespace ome
         /// The tag value type (C++ type).
         typedef typename ::ome::files::detail::tiff::TagProperties<tag_category>::value_type value_type;
 
+        /// Field uses internal IFD state.
         friend class IFD;
 
       protected:

--- a/lib/ome/files/tiff/IFD.cpp
+++ b/lib/ome/files/tiff/IFD.cpp
@@ -634,13 +634,12 @@ namespace ome
         {
         }
 
-      private:
-        /// Copy constructor (deleted).
-        Impl (const Impl&);
+        /// @cond SKIP
+        Impl (const Impl&) = delete;
 
-        /// Assignment operator (deleted).
         Impl&
-        operator= (const Impl&);
+        operator= (const Impl&) = delete;
+        /// @endcond SKIP
       };
 
       IFD::IFD(std::shared_ptr<TIFF>& tiff,

--- a/lib/ome/files/tiff/IFD.h
+++ b/lib/ome/files/tiff/IFD.h
@@ -75,20 +75,28 @@ namespace ome
         std::shared_ptr<Impl> impl;
 
       protected:
-        /// Constructor (not public).
+        /**
+         * Constructor (not public).
+         *
+         * @param tiff the TIFF this IFD belongs to.
+         * @param offset the IFD offset in the TIFF.
+         */
         IFD(std::shared_ptr<TIFF>& tiff,
             offset_type            offset);
 
-        /// Constructor (not public).
+        /**
+         * Constructor (not public).
+         *
+         * @param tiff the TIFF this IFD belongs to.
+         */
         IFD(std::shared_ptr<TIFF>& tiff);
 
-      private:
-        /// Copy constructor (deleted).
-        IFD (const IFD&);
+        /// @cond SKIP
+        IFD (const IFD&) = delete;
 
-        /// Assignment operator (deleted).
         IFD&
-        operator= (const IFD&);
+        operator= (const IFD&) = delete;
+        /// @endcond SKIP
 
       public:
         /// Destructor.

--- a/lib/ome/files/tiff/TIFF.cpp
+++ b/lib/ome/files/tiff/TIFF.cpp
@@ -163,15 +163,13 @@ namespace ome
             }
         }
 
-      private:
-        /// Copy constructor (deleted).
-        Impl (const Impl&);
+        /// @cond SKIP
+        Impl (const Impl&) = delete;
 
-        /// Assignment operator (deleted).
         Impl&
-        operator= (const Impl&);
+        operator= (const Impl&) = delete;
+        /// @endcond SKIP
 
-      public:
         /**
          * Close the libtiff file handle.
          *

--- a/lib/ome/files/tiff/TIFF.h
+++ b/lib/ome/files/tiff/TIFF.h
@@ -106,7 +106,9 @@ namespace ome
          */
         mutable std::shared_ptr<Value> pos;
 
+        /// IFD iterator internals uses internal TIFF state.
         friend class boost::iterator_core_access;
+        /// IFD iterator uses internal TIFF state.
         template <class> friend class IFDIterator;
 
         /**
@@ -160,17 +162,23 @@ namespace ome
         std::shared_ptr<Impl> impl;
 
       protected:
-        /// Constructor (non-public).
+        /**
+         * Constructor (non-public).
+         *
+         * @param filename the file to open.
+         * @param mode the file open mode (@c r to read, @c w to write
+         * or @c a to append).
+         * @throws an Exception on failure.
+         */
         TIFF(const boost::filesystem::path& filename,
              const std::string&             mode);
 
-      private:
-        /// Copy constructor (deleted).
-        TIFF (const TIFF&);
+        /// @cond SKIP
+        TIFF (const TIFF&) = delete;
 
-        /// Assignment operator (deleted).
         TIFF&
-        operator= (const TIFF&);
+        operator= (const TIFF&) = delete;
+        /// @endcond SKIP
 
       public:
         /// Destructor.
@@ -282,6 +290,7 @@ namespace ome
         wrapped_type *
         getWrapped() const;
 
+        /// IFD uses internal TIFF state.
         friend class IFD;
 
         /// IFD iterator.

--- a/lib/ome/files/tiff/TileInfo.h
+++ b/lib/ome/files/tiff/TileInfo.h
@@ -61,6 +61,7 @@ namespace ome
       class TileInfo
       {
       protected:
+        /// IFD uses protected TileInfo methods.
         friend class IFD;
 
         /**


### PR DESCRIPTION
Upgrade to the latest Doxygen configuration file version.

Doxygen can't handle deleted methods too well--it complains about
them not being documented despite them not existing at all, so
skip them entirely.

Testing: Check builds are green.