### PR TITLE
docs: Add extended metadata examples including annotations and references

### DIFF
--- a/docs/sphinx/examples/metadata-formatwriter.cpp
+++ b/docs/sphinx/examples/metadata-formatwriter.cpp
@@ -1,7 +1,7 @@
 /*
  * #%L
  * OME-FILES C++ library for image IO.
- * Copyright © 2015 Open Microscopy Environment:
+ * Copyright © 2015–2017 Open Microscopy Environment:
  *   - Massachusetts Institute of Technology
  *   - National Institutes of Health
  *   - University of Dundee
@@ -124,7 +124,8 @@ namespace
 
     // Create an Objective for this Instrument.
     MetadataStore::index_type objective_idx = 0;
-    std::string objective_id = createID("Objective", instrument_idx, objective_idx);
+    std::string objective_id = createID("Objective",
+                                        instrument_idx, objective_idx);
     store->setObjectiveID(objective_id, instrument_idx, objective_idx);
     store->setObjectiveManufacturer("InterFocal", instrument_idx, objective_idx);
     store->setObjectiveNominalMagnification(40, instrument_idx, objective_idx);
@@ -151,13 +152,15 @@ namespace
     MetadataStore::index_type map_annotation_idx = 0;
     std::string annotation_id = createID("Annotation", annotation_idx);
     store->setMapAnnotationID(annotation_id, map_annotation_idx);
-    store->setMapAnnotationNamespace("https://microscopy.example.com/colour-balance", map_annotation_idx);
+    store->setMapAnnotationNamespace
+      ("https://microscopy.example.com/colour-balance", map_annotation_idx);
     store->setMapAnnotationValue({{"white-balance", "5,15,8"},
           {"black-balance", "112,140,126"}}, map_annotation_idx);
 
     // Link MapAnnotation to Detector.
     MetadataStore::index_type detector_ref_idx = 0;
-    store->setDetectorAnnotationRef(annotation_id, instrument_idx, detector_idx, detector_ref_idx);
+    store->setDetectorAnnotationRef(annotation_id, instrument_idx, detector_idx,
+                                    detector_ref_idx);
 
     // Create a LongAnnotation.
     ++annotation_idx;
@@ -165,7 +168,8 @@ namespace
     annotation_id = createID("Annotation", annotation_idx);
     store->setLongAnnotationID(annotation_id, long_annotation_idx);
     store->setLongAnnotationValue(239423, long_annotation_idx);
-    store->setLongAnnotationNamespace("https://microscopy.example.com/trigger-delay", long_annotation_idx);
+    store->setLongAnnotationNamespace
+      ("https://microscopy.example.com/trigger-delay", long_annotation_idx);
 
     // Link LongAnnotation to Image.
     MetadataStore::index_type image_ref_idx = 0;
@@ -177,7 +181,8 @@ namespace
     annotation_id = createID("Annotation", annotation_idx);
     store->setLongAnnotationID(annotation_id, long_annotation_idx);
     store->setLongAnnotationValue(934223, long_annotation_idx);
-    store->setLongAnnotationNamespace("https://microscopy.example.com/sample-number", long_annotation_idx);
+    store->setLongAnnotationNamespace
+      ("https://microscopy.example.com/sample-number", long_annotation_idx);
 
     // Link second LongAnnotation to Image.
     ++image_ref_idx = 0;

--- a/docs/sphinx/examples/metadata-formatwriter.cpp
+++ b/docs/sphinx/examples/metadata-formatwriter.cpp
@@ -130,7 +130,8 @@ namespace
     store->setObjectiveNominalMagnification(40, instrument_idx, objective_idx);
     store->setObjectiveLensNA(0.4, instrument_idx, objective_idx);
     store->setObjectiveImmersion(Immersion::OIL, instrument_idx, objective_idx);
-    store->setObjectiveWorkingDistance({0.34, UnitsLength::MILLIMETER}, instrument_idx, objective_idx);
+    store->setObjectiveWorkingDistance({0.34, UnitsLength::MILLIMETER},
+                                       instrument_idx, objective_idx);
 
     // Create a Detector for this Instrument.
     MetadataStore::index_type detector_idx = 0;
@@ -250,7 +251,8 @@ namespace
             // Write the the entire pixel buffer to the plane.
             writer.saveBytes(p, vbuffer);
 
-            stream << "Wrote " << buffer->num_elements() << ' ' << buffer->pixelType() << " pixels\n";
+            stream << "Wrote " << buffer->num_elements() << ' '
+                   << buffer->pixelType() << " pixels\n";
           }
       }
     /* pixel-example-end */

--- a/docs/sphinx/examples/metadata-formatwriter.cpp
+++ b/docs/sphinx/examples/metadata-formatwriter.cpp
@@ -49,7 +49,9 @@
 using boost::filesystem::path;
 using std::make_shared;
 using std::shared_ptr;
+using std::static_pointer_cast;
 using ome::files::dimension_size_type;
+using ome::files::createID;
 using ome::files::fillMetadata;
 using ome::files::CoreMetadata;
 using ome::files::DIM_SPATIAL_X;
@@ -62,18 +64,26 @@ using ome::files::PixelBuffer;
 using ome::files::PixelBufferBase;
 using ome::files::PixelProperties;
 using ome::files::VariantPixelBuffer;
+using ome::xml::model::enums::Binning;
+using ome::xml::model::enums::Immersion;
 using ome::xml::model::enums::PixelType;
+using ome::xml::model::enums::DetectorType;
 using ome::xml::model::enums::DimensionOrder;
+using ome::xml::model::enums::UnitsLength;
+using ome::xml::meta::MetadataRetrieve;
+using ome::xml::meta::MetadataStore;
+using ome::xml::meta::Metadata;
+using ome::xml::meta::OMEXMLMetadata;
 
 namespace
 {
 
-  /* write-example-start */
-  shared_ptr<::ome::xml::meta::OMEXMLMetadata>
+  shared_ptr<OMEXMLMetadata>
   createMetadata()
   {
+    /* create-metadata-start */
     // OME-XML metadata store.
-    shared_ptr<::ome::xml::meta::OMEXMLMetadata> meta(make_shared<::ome::xml::meta::OMEXMLMetadata>());
+    auto meta = make_shared<OMEXMLMetadata>();
 
     // Create simple CoreMetadata and use this to set up the OME-XML
     // metadata.  This is purely for convenience in this example; a
@@ -93,16 +103,95 @@ namespace
     seriesList.push_back(core); // add two identical series
 
     fillMetadata(*meta, seriesList);
+    /* create-metadata-end */
 
     return meta;
   }
-  /* write-example-end */
 
-  /* pixel-example-start */
+  void
+  addExtendedMetadata(shared_ptr<OMEXMLMetadata> store)
+  {
+    /* extended-metadata-start */
+    // There is one image with one channel in this image.
+    MetadataStore::index_type image_idx = 0;
+    MetadataStore::index_type channel_idx = 0;
+    MetadataStore::index_type annotation_idx = 0;
+
+    // Create an Instrument.
+    MetadataStore::index_type instrument_idx = 0;
+    std::string instrument_id = createID("Instrument", instrument_idx);
+    store->setInstrumentID(instrument_id, instrument_idx);
+
+    // Create an Objective for this Instrument.
+    MetadataStore::index_type objective_idx = 0;
+    std::string objective_id = createID("Objective", instrument_idx, objective_idx);
+    store->setObjectiveID(objective_id, instrument_idx, objective_idx);
+    store->setObjectiveManufacturer("InterFocal", instrument_idx, objective_idx);
+    store->setObjectiveNominalMagnification(40, instrument_idx, objective_idx);
+    store->setObjectiveLensNA(0.4, instrument_idx, objective_idx);
+    store->setObjectiveImmersion(Immersion::OIL, instrument_idx, objective_idx);
+    store->setObjectiveWorkingDistance({0.34, UnitsLength::MILLIMETER}, instrument_idx, objective_idx);
+
+    // Create a Detector for this Instrument.
+    MetadataStore::index_type detector_idx = 0;
+    std::string detector_id = createID("Detector", instrument_idx, detector_idx);
+    store->setDetectorID(detector_id, instrument_idx, detector_idx);
+    store->setObjectiveManufacturer("MegaCapture", instrument_idx, detector_idx);
+    store->setDetectorType(DetectorType::CCD, instrument_idx, detector_idx);
+
+    // Create Settings for this Detector for the Channel on the Image.
+    store->setDetectorSettingsID(detector_id, image_idx, channel_idx);
+    store->setDetectorSettingsBinning(Binning::TWOBYTWO, image_idx, channel_idx);
+    store->setDetectorSettingsGain(56.89, image_idx, channel_idx);
+    /* extended-metadata-end */
+
+    /* annotations-start */
+    // Create a MapAnnotation.
+    MetadataStore::index_type map_annotation_idx = 0;
+    std::string annotation_id = createID("Annotation", annotation_idx);
+    store->setMapAnnotationID(annotation_id, map_annotation_idx);
+    store->setMapAnnotationNamespace("https://microscopy.example.com/colour-balance", map_annotation_idx);
+    store->setMapAnnotationValue({{"white-balance", "5,15,8"},
+          {"black-balance", "112,140,126"}}, map_annotation_idx);
+
+    // Link MapAnnotation to Detector.
+    MetadataStore::index_type detector_ref_idx = 0;
+    store->setDetectorAnnotationRef(annotation_id, instrument_idx, detector_idx, detector_ref_idx);
+
+    // Create a LongAnnotation.
+    ++annotation_idx;
+    MetadataStore::index_type long_annotation_idx = 0;
+    annotation_id = createID("Annotation", annotation_idx);
+    store->setLongAnnotationID(annotation_id, long_annotation_idx);
+    store->setLongAnnotationValue(239423, long_annotation_idx);
+    store->setLongAnnotationNamespace("https://microscopy.example.com/trigger-delay", long_annotation_idx);
+
+    // Link LongAnnotation to Image.
+    MetadataStore::index_type image_ref_idx = 0;
+    store->setImageAnnotationRef(annotation_id, image_idx, image_ref_idx);
+
+    // Create a second LongAnnotation.
+    ++annotation_idx;
+    ++long_annotation_idx;
+    annotation_id = createID("Annotation", annotation_idx);
+    store->setLongAnnotationID(annotation_id, long_annotation_idx);
+    store->setLongAnnotationValue(934223, long_annotation_idx);
+    store->setLongAnnotationNamespace("https://microscopy.example.com/sample-number", long_annotation_idx);
+
+    // Link second LongAnnotation to Image.
+    ++image_ref_idx = 0;
+    store->setImageAnnotationRef(annotation_id, image_idx, image_ref_idx);
+
+    // Update all the annotation cross-references.
+    store->resolveReferences();
+    /* annotations-end */
+  }
+
   void
   writePixelData(FormatWriter& writer,
                  std::ostream& stream)
   {
+    /* pixel-example-start */
     // Total number of images (series)
     dimension_size_type ic = writer.getMetadataRetrieve()->getImageCount();
     stream << "Image count: " << ic << '\n';
@@ -144,7 +233,7 @@ namespace
                   std::fill(idx.begin(), idx.end(), 0);
                   idx[DIM_SPATIAL_X] = x;
                   idx[DIM_SPATIAL_Y] = y;
-                  
+
                   idx[DIM_SUBCHANNEL] = 0;
                   buffer->at(idx) = (static_cast<float>(x) / 512.0f) * 4096.0f;
                   idx[DIM_SUBCHANNEL] = 1;
@@ -164,8 +253,8 @@ namespace
             stream << "Wrote " << buffer->num_elements() << ' ' << buffer->pixelType() << " pixels\n";
           }
       }
+    /* pixel-example-end */
   }
-  /* pixel-example-end */
 
 }
 
@@ -183,14 +272,17 @@ main(int argc, char *argv[])
           path filename(argv[1]);
 
           /* writer-example-start */
-          // Create metadata for the file to be written.
-          shared_ptr<::ome::xml::meta::MetadataRetrieve> meta(createMetadata());
+          // Create minimal metadata for the file to be written.
+          auto meta = createMetadata();
+          // Add extended metadata.
+          addExtendedMetadata(meta);
 
           // Create TIFF writer
-          shared_ptr<FormatWriter> writer(make_shared<OMETIFFWriter>());
+          auto writer = make_shared<OMETIFFWriter>();
 
           // Set writer options before opening a file
-          writer->setMetadataRetrieve(meta);
+          auto retrieve = static_pointer_cast<MetadataRetrieve>(meta);
+          writer->setMetadataRetrieve(retrieve);
           writer->setInterleaved(false);
           writer->setTileSizeX(256);
           writer->setTileSizeY(256);

--- a/docs/sphinx/examples/metadata-formatwriter2.cpp
+++ b/docs/sphinx/examples/metadata-formatwriter2.cpp
@@ -1,7 +1,7 @@
 /*
 * #%L
 * OME-FILES C++ library for image IO.
-* Copyright © 2015 Open Microscopy Environment:
+* Copyright © 2015–2017 Open Microscopy Environment:
 *   - Massachusetts Institute of Technology
 *   - National Institutes of Health
 *   - University of Dundee
@@ -126,7 +126,9 @@ namespace
   {
     /* extended-metadata-start */
     // Get root OME object
-    std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(store->getRoot()));
+    std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot>
+      root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>
+           (store->getRoot()));
     if (!root)
       return;
 
@@ -148,7 +150,8 @@ namespace
     objective->setLensNA(objective_na);
     auto objective_immersion = std::make_shared<Immersion>(Immersion::OIL);
     objective->setImmersion(objective_immersion);
-    auto objective_wd = std::make_shared<Quantity<UnitsLength>>(0.34, UnitsLength::MILLIMETER);
+    auto objective_wd = std::make_shared<Quantity<UnitsLength>>
+      (0.34, UnitsLength::MILLIMETER);
     objective->setWorkingDistance(objective_wd);
     instrument->addObjective(objective);
 
@@ -212,7 +215,8 @@ namespace
     auto map_ann0 = std::make_shared<ome::xml::model::MapAnnotation>();
     std::string annotation_id = createID("Annotation", annotation_idx);
     map_ann0->setID(annotation_id);
-    auto map_ann0_ns = std::make_shared<std::string>("https://microscopy.example.com/colour-balance");
+    auto map_ann0_ns = std::make_shared<std::string>
+      ("https://microscopy.example.com/colour-balance");
     map_ann0->setNamespace(map_ann0_ns);
     map_ann0->setValue({{"white-balance", "5,15,8"},
           {"black-balance", "112,140,126"}});
@@ -226,7 +230,8 @@ namespace
     ++annotation_idx;
     annotation_id = createID("Annotation", annotation_idx);
     long_ann0->setID(annotation_id);
-    auto long_ann0_ns = std::make_shared<std::string>("https://microscopy.example.com/trigger-delay");
+    auto long_ann0_ns = std::make_shared<std::string>
+      ("https://microscopy.example.com/trigger-delay");
     long_ann0->setNamespace(long_ann0_ns);
     long_ann0->setValue(239423);
     sa->addLongAnnotation(long_ann0);
@@ -239,7 +244,8 @@ namespace
     ++annotation_idx;
     annotation_id = createID("Annotation", annotation_idx);
     long_ann1->setID(annotation_id);
-    auto long_ann1_ns = std::make_shared<std::string>("https://microscopy.example.com/sample-number");
+    auto long_ann1_ns = std::make_shared<std::string>
+      ("https://microscopy.example.com/sample-number");
     long_ann1->setNamespace(long_ann1_ns);
     long_ann1->setValue(934223);
 

--- a/docs/sphinx/examples/metadata-formatwriter2.cpp
+++ b/docs/sphinx/examples/metadata-formatwriter2.cpp
@@ -248,6 +248,7 @@ namespace
       ("https://microscopy.example.com/sample-number");
     long_ann1->setNamespace(long_ann1_ns);
     long_ann1->setValue(934223);
+    sa->addLongAnnotation(long_ann1);
 
     // Link second LongAnnotation to Image.
     image->linkAnnotation(long_ann1);

--- a/docs/sphinx/examples/metadata-formatwriter2.cpp
+++ b/docs/sphinx/examples/metadata-formatwriter2.cpp
@@ -92,7 +92,7 @@ namespace
   shared_ptr<OMEXMLMetadata>
   createMetadata()
   {
-    /* core-metadata-start */
+    /* create-metadata-start */
     // OME-XML metadata store.
     auto meta = make_shared<OMEXMLMetadata>();
 
@@ -116,7 +116,7 @@ namespace
     seriesList.push_back(core); // add two identical series
 
     fillMetadata(*meta, seriesList);
-    /* core-metadata-end */
+    /* create-metadata-end */
 
     return meta;
   }

--- a/docs/sphinx/examples/metadata-formatwriter2.cpp
+++ b/docs/sphinx/examples/metadata-formatwriter2.cpp
@@ -45,10 +45,22 @@
 #include <ome/files/VariantPixelBuffer.h>
 #include <ome/files/out/OMETIFFWriter.h>
 #include <ome/xml/meta/OMEXMLMetadata.h>
+#include <ome/xml/model/AnnotationRef.h>
+#include <ome/xml/model/Channel.h>
+#include <ome/xml/model/Detector.h>
+#include <ome/xml/model/DetectorSettings.h>
+#include <ome/xml/model/Image.h>
+#include <ome/xml/model/Instrument.h>
+#include <ome/xml/model/LongAnnotation.h>
+#include <ome/xml/model/MapAnnotation.h>
+#include <ome/xml/model/OME.h>
+#include <ome/xml/model/Objective.h>
 
 using boost::filesystem::path;
 using std::make_shared;
 using std::shared_ptr;
+using std::static_pointer_cast;
+using ome::files::createID;
 using ome::files::dimension_size_type;
 using ome::files::fillMetadata;
 using ome::files::CoreMetadata;
@@ -62,18 +74,27 @@ using ome::files::PixelBuffer;
 using ome::files::PixelBufferBase;
 using ome::files::PixelProperties;
 using ome::files::VariantPixelBuffer;
+using ome::xml::model::enums::Binning;
+using ome::xml::model::enums::Immersion;
 using ome::xml::model::enums::PixelType;
+using ome::xml::model::enums::DetectorType;
 using ome::xml::model::enums::DimensionOrder;
+using ome::xml::model::enums::UnitsLength;
+using ome::xml::model::primitives::Quantity;
+using ome::xml::meta::MetadataRetrieve;
+using ome::xml::meta::MetadataStore;
+using ome::xml::meta::Metadata;
+using ome::xml::meta::OMEXMLMetadata;
 
 namespace
 {
 
-  /* write-example-start */
-  shared_ptr<::ome::xml::meta::OMEXMLMetadata>
+  shared_ptr<OMEXMLMetadata>
   createMetadata()
   {
+    /* core-metadata-start */
     // OME-XML metadata store.
-    shared_ptr<::ome::xml::meta::OMEXMLMetadata> meta(make_shared<::ome::xml::meta::OMEXMLMetadata>());
+    auto meta = make_shared<OMEXMLMetadata>();
 
     // Create simple CoreMetadata and use this to set up the OME-XML
     // metadata.  This is purely for convenience in this example; a
@@ -87,7 +108,7 @@ namespace
     core->sizeC.push_back(1);
     core->sizeC.push_back(1);
     core->sizeC.push_back(1);
-    core->pixelType = ome::xml::model::enums::PixelType::UINT16;
+    core->pixelType = PixelType::UINT16;
     core->interleaved = false;
     core->bitsPerPixel = 12U;
     core->dimensionOrder = DimensionOrder::XYZTC;
@@ -95,16 +116,143 @@ namespace
     seriesList.push_back(core); // add two identical series
 
     fillMetadata(*meta, seriesList);
+    /* core-metadata-end */
 
     return meta;
   }
-  /* write-example-end */
 
-  /* pixel-example-start */
+  void
+  addExtendedMetadata(shared_ptr<OMEXMLMetadata> store)
+  {
+    /* extended-metadata-start */
+    // Get root OME object
+    std::shared_ptr<ome::xml::meta::OMEXMLMetadataRoot> root(std::dynamic_pointer_cast<ome::xml::meta::OMEXMLMetadataRoot>(store->getRoot()));
+    if (!root)
+      return;
+
+    MetadataStore::index_type annotation_idx = 0;
+
+    // Create an Instrument.
+    auto instrument = make_shared<ome::xml::model::Instrument>();
+    instrument->setID(createID("Instrument", 0));
+    root->addInstrument(instrument);
+
+    // Create an Objective for this Instrument.
+    auto objective = make_shared<ome::xml::model::Objective>();
+    objective->setID(createID("Objective", 0));
+    auto objective_manufacturer = std::make_shared<std::string>("InterFocal");
+    objective->setManufacturer(objective_manufacturer);
+    auto objective_nominal_mag = std::make_shared<double>(40.0);
+    objective->setNominalMagnification(objective_nominal_mag);
+    auto objective_na = std::make_shared<double>(0.4);
+    objective->setLensNA(objective_na);
+    auto objective_immersion = std::make_shared<Immersion>(Immersion::OIL);
+    objective->setImmersion(objective_immersion);
+    auto objective_wd = std::make_shared<Quantity<UnitsLength>>(0.34, UnitsLength::MILLIMETER);
+    objective->setWorkingDistance(objective_wd);
+    instrument->addObjective(objective);
+
+    // Create a Detector for this Instrument.
+    auto detector = make_shared<ome::xml::model::Detector>();
+    std::string detector_id = createID("Detector", 0);
+    detector->setID(detector_id);
+    auto detector_manufacturer = std::make_shared<std::string>("MegaCapture");
+    detector->setManufacturer(detector_manufacturer);
+    auto detector_type = std::make_shared<DetectorType>(DetectorType::CCD);
+    detector->setType(detector_type);
+    instrument->addDetector(detector);
+
+    // Get Image and Channel for future use.  Note for your own code,
+    // you should check that the elements exist before accessing them;
+    // here we know they are valid because we created them above.
+    auto image = root->getImage(0);
+    auto pixels = image->getPixels();
+    auto channel0 = pixels->getChannel(0);
+    auto channel1 = pixels->getChannel(1);
+    auto channel2 = pixels->getChannel(2);
+
+    // Create Settings for this Detector for each Channel on the Image.
+    auto detector_settings0 = make_shared<ome::xml::model::DetectorSettings>();
+    {
+      detector_settings0->setID(detector_id);
+      auto detector_binning = std::make_shared<Binning>(Binning::TWOBYTWO);
+      detector_settings0->setBinning(detector_binning);
+      auto detector_gain = std::make_shared<double>(83.81);
+      detector_settings0->setGain(detector_gain);
+      channel0->setDetectorSettings(detector_settings0);
+    }
+
+    auto detector_settings1 = make_shared<ome::xml::model::DetectorSettings>();
+    {
+      detector_settings1->setID(detector_id);
+      auto detector_binning = std::make_shared<Binning>(Binning::TWOBYTWO);
+      detector_settings1->setBinning(detector_binning);
+      auto detector_gain = std::make_shared<double>(56.89);
+      detector_settings1->setGain(detector_gain);
+      channel1->setDetectorSettings(detector_settings1);
+    }
+
+    auto detector_settings2 = make_shared<ome::xml::model::DetectorSettings>();
+    {
+      detector_settings2->setID(detector_id);
+      auto detector_binning = std::make_shared<Binning>(Binning::FOURBYFOUR);
+      detector_settings2->setBinning(detector_binning);
+      auto detector_gain = std::make_shared<double>(12.93);
+      detector_settings2->setGain(detector_gain);
+      channel2->setDetectorSettings(detector_settings2);
+    }
+    /* extended-metadata-end */
+
+    /* annotations-start */
+    // Add Structured Annotations.
+    auto sa = std::make_shared<ome::xml::model::StructuredAnnotations>();
+    root->setStructuredAnnotations(sa);
+
+    // Create a MapAnnotation.
+    auto map_ann0 = std::make_shared<ome::xml::model::MapAnnotation>();
+    std::string annotation_id = createID("Annotation", annotation_idx);
+    map_ann0->setID(annotation_id);
+    auto map_ann0_ns = std::make_shared<std::string>("https://microscopy.example.com/colour-balance");
+    map_ann0->setNamespace(map_ann0_ns);
+    map_ann0->setValue({{"white-balance", "5,15,8"},
+          {"black-balance", "112,140,126"}});
+    sa->addMapAnnotation(map_ann0);
+
+    // Link MapAnnotation to Detector.
+    detector->linkAnnotation(map_ann0);
+
+    // Create a LongAnnotation.
+    auto long_ann0 = std::make_shared<ome::xml::model::LongAnnotation>();
+    ++annotation_idx;
+    annotation_id = createID("Annotation", annotation_idx);
+    long_ann0->setID(annotation_id);
+    auto long_ann0_ns = std::make_shared<std::string>("https://microscopy.example.com/trigger-delay");
+    long_ann0->setNamespace(long_ann0_ns);
+    long_ann0->setValue(239423);
+    sa->addLongAnnotation(long_ann0);
+
+    // Link LongAnnotation to Image.
+    image->linkAnnotation(long_ann0);
+
+    // Create a second LongAnnotation.
+    auto long_ann1 = std::make_shared<ome::xml::model::LongAnnotation>();
+    ++annotation_idx;
+    annotation_id = createID("Annotation", annotation_idx);
+    long_ann1->setID(annotation_id);
+    auto long_ann1_ns = std::make_shared<std::string>("https://microscopy.example.com/sample-number");
+    long_ann1->setNamespace(long_ann1_ns);
+    long_ann1->setValue(934223);
+
+    // Link second LongAnnotation to Image.
+    image->linkAnnotation(long_ann1);
+    /* annotations-end */
+  }
+
   void
   writePixelData(FormatWriter& writer,
                  std::ostream& stream)
   {
+    /* pixel-example-start */
     // Total number of images (series)
     dimension_size_type ic = writer.getMetadataRetrieve()->getImageCount();
     stream << "Image count: " << ic << '\n';
@@ -179,14 +327,17 @@ namespace
             stream << "Wrote " << buffer->num_elements() << ' ' << buffer->pixelType() << " pixels\n";
           }
       }
+    /* pixel-example-end */
   }
-  /* pixel-example-end */
 
 }
 
 int
 main(int argc, char *argv[])
 {
+  // This is the default, but needs setting manually on Windows.
+  ome::common::setLogLevel(ome::logging::trivial::warning);
+
   try
     {
       if (argc > 1)
@@ -196,13 +347,16 @@ main(int argc, char *argv[])
 
           /* writer-example-start */
           // Create metadata for the file to be written.
-          shared_ptr<::ome::xml::meta::MetadataRetrieve> meta(createMetadata());
+          auto meta = createMetadata();
+          // Add extended metadata.
+          addExtendedMetadata(meta);
 
           // Create TIFF writer
-          shared_ptr<FormatWriter> writer(make_shared<OMETIFFWriter>());
+          auto writer = make_shared<OMETIFFWriter>();
 
           // Set writer options before opening a file
-          writer->setMetadataRetrieve(meta);
+          auto retrieve = static_pointer_cast<MetadataRetrieve>(meta);
+          writer->setMetadataRetrieve(retrieve);
           writer->setInterleaved(false);
 
           // Open the file

--- a/docs/sphinx/tutorial.rst
+++ b/docs/sphinx/tutorial.rst
@@ -235,8 +235,8 @@ used in this situation to create a suitable metadata store:
 
 .. literalinclude:: examples/metadata-formatwriter.cpp
    :language: cpp
-   :start-after: core-metadata-start
-   :end-before: core-metadata-end
+   :start-after: create-metadata-start
+   :end-before: create-metadata-end
 
 Full example source: :download:`metadata-formatreader.cpp
 <examples/metadata-formatreader.cpp>`,
@@ -480,6 +480,8 @@ possible using model objects directly:
    :end-before: annotations-end
 
 Full example source: :download:`model-io.cpp <examples/model-io.cpp>`
+and :download:`metadata-formatwriter2.cpp
+<examples/metadata-formatwriter2.cpp>`
 
 .. seealso::
 

--- a/docs/sphinx/tutorial.rst
+++ b/docs/sphinx/tutorial.rst
@@ -398,12 +398,12 @@ basis if they vary during the course of acquisition.
 
 If the existing data model elements and attributes are insufficient
 for describing the complexity of your hardware or experimental setup,
-it's possible to extend it with custom annotations.  These annotations
-exist globally, but may be referenced where needed, and may be
-referenced by multiple model elements if required.  In the follow
-example, we create and attach an annotation to the ``Detector``
-element, and then create and attach two annotations to the first
-``Image`` element.
+it is possible to extend it with custom annotations.  These
+annotations exist globally, but may be referenced by a model element
+where needed, and may be referenced by multiple model elements if
+required.  In the following example, we create and attach an
+annotation to the ``Detector`` element, and then create and attach two
+annotations to the first ``Image`` element.
 
 .. literalinclude:: examples/metadata-formatwriter.cpp
    :language: cpp
@@ -459,11 +459,11 @@ method is used to copy the data from the OME root object and its
 children into an XML DOM tree.  The DOM tree is then converted to text
 for output.
 
-As shown previously for the :cpp:class:`MetadataStore`, it is also
+As shown previously for the :cpp:class:`MetadataStore` API, it is also
 possible to create and modify extended metadata elements using the
-model objects directly.  The following example, demonstrates the setup
+model objects directly.  The following example demonstrates the setup
 of the microscope during acquisition, including its objective and
-detector parameters to achieve the same effect as in the example
+detector parameters, to achieve the same effect as in the example
 above.
 
 .. literalinclude:: examples/metadata-formatwriter2.cpp

--- a/docs/sphinx/tutorial.rst
+++ b/docs/sphinx/tutorial.rst
@@ -235,8 +235,8 @@ used in this situation to create a suitable metadata store:
 
 .. literalinclude:: examples/metadata-formatwriter.cpp
    :language: cpp
-   :start-after: write-example-start
-   :end-before: write-example-end
+   :start-after: core-metadata-start
+   :end-before: core-metadata-end
 
 Full example source: :download:`metadata-formatreader.cpp
 <examples/metadata-formatreader.cpp>`,
@@ -383,7 +383,36 @@ objects.
    :start-after: add-example-start
    :end-before: add-example-end
 
-Full example source: :download:`metadata-io.cpp <examples/metadata-io.cpp>`
+In addition to this basic metadata, it is possible to create and
+modify extended metadata elements.  In the following example, we
+describe the setup of the microscope during acquisition, including its
+objective and detector parameters.  Only a few parameters are set
+here; it is possible to completely describe the instrument
+configuration, including the settings on a per-image and per-channel
+basis if they vary during the course of acquisition.
+
+.. literalinclude:: examples/metadata-formatwriter.cpp
+   :language: cpp
+   :start-after: extended-metadata-start
+   :end-before: extended-metadata-end
+
+If the existing data model elements and attributes are insufficient
+for describing the complexity of your hardware or experimental setup,
+it's possible to extend it with custom annotations.  These annotations
+exist globally, but may be referenced where needed, and may be
+referenced by multiple model elements if required.  In the follow
+example, we create and attach an annotation to the ``Detector``
+element, and then create and attach two annotations to the first
+``Image`` element.
+
+.. literalinclude:: examples/metadata-formatwriter.cpp
+   :language: cpp
+   :start-after: annotations-start
+   :end-before: annotations-end
+
+Full example source: :download:`metadata-io.cpp
+<examples/metadata-io.cpp>` and :download:`metadata-formatwriter.cpp
+<examples/metadata-formatwriter.cpp>`
 
 .. seealso::
 

--- a/docs/sphinx/tutorial.rst
+++ b/docs/sphinx/tutorial.rst
@@ -459,6 +459,26 @@ method is used to copy the data from the OME root object and its
 children into an XML DOM tree.  The DOM tree is then converted to text
 for output.
 
+As shown previously for the :cpp:class:`MetadataStore`, it is also
+possible to create and modify extended metadata elements using the
+model objects directly.  The following example, demonstrates the setup
+of the microscope during acquisition, including its objective and
+detector parameters to achieve the same effect as in the example
+above.
+
+.. literalinclude:: examples/metadata-formatwriter2.cpp
+   :language: cpp
+   :start-after: extended-metadata-start
+   :end-before: extended-metadata-end
+
+Creating annotations and linking them to model objects is also
+possible using model objects directly:
+
+.. literalinclude:: examples/metadata-formatwriter2.cpp
+   :language: cpp
+   :start-after: annotations-start
+   :end-before: annotations-end
+
 Full example source: :download:`model-io.cpp <examples/model-io.cpp>`
 
 .. seealso::


### PR DESCRIPTION
See [trello card](https://trello.com/c/oEwb3o57/34-add-writer-examples)

Testing:

- check builds are green
- check tutorial page in docs, see [staging docs](http://www.openmicroscopy.org/site/support/ome-files-cpp-staging/ome-files/manual/html/tutorial.html)
- check emitted model is valid (it validates, but is it semantically valid with regard to annotation names, references)?

metadata-formatwriter:

```
<?xml version="1.0" encoding="UTF-8" standalone="no" ?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" UUID="urn:uuid:d5426311-a8b1-45f3-835d-7a6c703bc50a" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"><!-- Warning: this comment is within an OME-XML metadata block, which contains crucial dimensional parameters and other important metadata. Please edit cautiously (if at all), and back up the original data before doing so. For more information, see the OME-TIFF web site: http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/ --><Instrument ID="Instrument:0"><Detector ID="Detector:0:0" Type="CCD"><AnnotationRef ID="Annotation:0"/></Detector><Objective ID="Objective:0:0" Immersion="Oil" LensNA="0.4" Manufacturer="MegaCapture" NominalMagnification="40" WorkingDistance="0.34" WorkingDistanceUnit="mm"/></Instrument><Image ID="Image:0"><Pixels BigEndian="true" DimensionOrder="XYZTC" ID="Pixels:0" Interleaved="false" SignificantBits="12" SizeC="3" SizeT="1" SizeX="512" SizeY="512" SizeZ="1" Type="uint16"><Channel ID="Channel:0:0" SamplesPerPixel="3"><DetectorSettings Binning="2x2" Gain="56.89" ID="Detector:0:0"/></Channel><TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1"><UUID FileName="test-write.ome.tiff">urn:uuid:d5426311-a8b1-45f3-835d-7a6c703bc50a</UUID></TiffData></Pixels><AnnotationRef ID="Annotation:1"/><AnnotationRef ID="Annotation:2"/></Image><Image ID="Image:1"><Pixels BigEndian="true" DimensionOrder="XYZTC" ID="Pixels:1" Interleaved="false" SignificantBits="12" SizeC="3" SizeT="1" SizeX="512" SizeY="512" SizeZ="1" Type="uint16"><Channel ID="Channel:1:0" SamplesPerPixel="3"/><TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="1" PlaneCount="1"><UUID FileName="test-write.ome.tiff">urn:uuid:d5426311-a8b1-45f3-835d-7a6c703bc50a</UUID></TiffData></Pixels></Image><StructuredAnnotations><LongAnnotation ID="Annotation:1" Namespace="https://microscopy.example.com/trigger-delay"><Value>239423</Value></LongAnnotation><LongAnnotation ID="Annotation:2" Namespace="https://microscopy.example.com/sample-number"><Value>934223</Value></LongAnnotation><MapAnnotation ID="Annotation:0" Namespace="https://microscopy.example.com/colour-balance"><Value><M K="white-balance">5,15,8</M><M K="black-balance">112,140,126</M></Value></MapAnnotation></StructuredAnnotations></OME>
```

metadata-formatwriter2:

```
<?xml version="1.0" encoding="UTF-8" standalone="no" ?><OME xmlns="http://www.openmicroscopy.org/Schemas/OME/2016-06" UUID="urn:uuid:40deefbd-3645-4ed0-ba2c-b28713ee00f7" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.openmicroscopy.org/Schemas/OME/2016-06 http://www.openmicroscopy.org/Schemas/OME/2016-06/ome.xsd"><!-- Warning: this comment is within an OME-XML metadata block, which contains crucial dimensional parameters and other important metadata. Please edit cautiously (if at all), and back up the original data before doing so. For more information, see the OME-TIFF web site: http://www.openmicroscopy.org/site/support/ome-model/ome-tiff/ --><Instrument ID="Instrument:0"><Detector ID="Detector:0" Manufacturer="MegaCapture" Type="CCD"><AnnotationRef ID="Annotation:0"/></Detector><Objective ID="Objective:0" Immersion="Oil" LensNA="0.4" Manufacturer="InterFocal" NominalMagnification="40" WorkingDistance="0.34" WorkingDistanceUnit="mm"/></Instrument><Image ID="Image:0"><Pixels BigEndian="true" DimensionOrder="XYZTC" ID="Pixels:0" Interleaved="false" SignificantBits="12" SizeC="3" SizeT="1" SizeX="512" SizeY="512" SizeZ="1" Type="uint16"><Channel ID="Channel:0:0" SamplesPerPixel="1"><DetectorSettings Binning="2x2" Gain="83.81" ID="Detector:0"/></Channel><Channel ID="Channel:0:1" SamplesPerPixel="1"><DetectorSettings Binning="2x2" Gain="56.89" ID="Detector:0"/></Channel><Channel ID="Channel:0:2" SamplesPerPixel="1"><DetectorSettings Binning="4x4" Gain="12.93" ID="Detector:0"/></Channel><TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="0" PlaneCount="1"><UUID FileName="test-write2.ome.tiff">urn:uuid:40deefbd-3645-4ed0-ba2c-b28713ee00f7</UUID></TiffData><TiffData FirstC="1" FirstT="0" FirstZ="0" IFD="1" PlaneCount="1"><UUID FileName="test-write2.ome.tiff">urn:uuid:40deefbd-3645-4ed0-ba2c-b28713ee00f7</UUID></TiffData><TiffData FirstC="2" FirstT="0" FirstZ="0" IFD="2" PlaneCount="1"><UUID FileName="test-write2.ome.tiff">urn:uuid:40deefbd-3645-4ed0-ba2c-b28713ee00f7</UUID></TiffData></Pixels><AnnotationRef ID="Annotation:1"/></Image><Image ID="Image:1"><Pixels BigEndian="true" DimensionOrder="XYZTC" ID="Pixels:1" Interleaved="false" SignificantBits="12" SizeC="3" SizeT="1" SizeX="512" SizeY="512" SizeZ="1" Type="uint16"><Channel ID="Channel:1:0" SamplesPerPixel="1"/><Channel ID="Channel:1:1" SamplesPerPixel="1"/><Channel ID="Channel:1:2" SamplesPerPixel="1"/><TiffData FirstC="0" FirstT="0" FirstZ="0" IFD="3" PlaneCount="1"><UUID FileName="test-write2.ome.tiff">urn:uuid:40deefbd-3645-4ed0-ba2c-b28713ee00f7</UUID></TiffData><TiffData FirstC="1" FirstT="0" FirstZ="0" IFD="4" PlaneCount="1"><UUID FileName="test-write2.ome.tiff">urn:uuid:40deefbd-3645-4ed0-ba2c-b28713ee00f7</UUID></TiffData><TiffData FirstC="2" FirstT="0" FirstZ="0" IFD="5" PlaneCount="1"><UUID FileName="test-write2.ome.tiff">urn:uuid:40deefbd-3645-4ed0-ba2c-b28713ee00f7</UUID></TiffData></Pixels></Image><StructuredAnnotations><LongAnnotation ID="Annotation:1" Namespace="https://microscopy.example.com/trigger-delay"><Value>239423</Value></LongAnnotation><MapAnnotation ID="Annotation:0" Namespace="https://microscopy.example.com/colour-balance"><Value><M K="white-balance">5,15,8</M><M K="black-balance">112,140,126</M></Value></MapAnnotation></StructuredAnnotations></OME>
```

There are some followup items which we should tackle for the next release which I'll add to the board.