### PR TITLE
ome-files: Wrapper documentation fixes

### DIFF
--- a/cmake/TemplateCmdWrapper.cmake.in
+++ b/cmake/TemplateCmdWrapper.cmake.in
@@ -154,7 +154,7 @@ for %%e in (%PATHEXT%) do (
     )
 )
 if [%foundcmd%]==[] (
-  echo ome-files: '%realcmd%' is not a ome-files-test command.  See 'ome-files --help'" >&2
+  echo ome-files: '%realcmd%' is not a ome-files command.  See 'ome-files --help'" >&2
   exit /b 1
 )
 

--- a/cmake/TemplateShellWrapper.cmake.in
+++ b/cmake/TemplateShellWrapper.cmake.in
@@ -161,7 +161,7 @@ run() {
   realcmd="$LIBEXECDIR/$realcmd"
 
   if [ ! -x "$realcmd" ]; then
-    echo "ome-files: '$runcmd' is not a ome-files command.  See 'ome-files-test --help'" >&2
+    echo "ome-files: '$runcmd' is not a ome-files command.  See 'ome-files --help'" >&2
     exit 1
   fi
 

--- a/cmake/TemplateShellWrapper.cmake.in
+++ b/cmake/TemplateShellWrapper.cmake.in
@@ -161,7 +161,7 @@ run() {
   realcmd="$LIBEXECDIR/$realcmd"
 
   if [ ! -x "$realcmd" ]; then
-    echo "ome-files: '$runcmd' is not a ome-files-test command.  See 'ome-files-test --help'" >&2
+    echo "ome-files: '$runcmd' is not a ome-files command.  See 'ome-files-test --help'" >&2
     exit 1
   fi
 

--- a/docs/sphinx/commands/ome-files.rst
+++ b/docs/sphinx/commands/ome-files.rst
@@ -39,7 +39,8 @@ Commonly-used commands are:
 info (or showinf)
   Display and validate image metadata
 view (or glview)
-  View image pixel data
+  View image pixel data [optional component; only present if built with
+  Qt5 and OpenGL support]
 
 See also
 --------


### PR DESCRIPTION
- Remove last two remaining instances of `ome-files-test`; now called `ome-files`
- Document that `ome-files view` may not work if support was not compiled in