### PR TITLE
cmake: Remove REQUIRED from exported configuration

### DIFF
--- a/lib/ome/files/OMEFilesConfig.cmake.in
+++ b/lib/ome/files/OMEFilesConfig.cmake.in
@@ -1,9 +1,9 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(OMECommon REQUIRED COMPONENTS Common XML)
-find_dependency(Boost 1.46 REQUIRED COMPONENTS boost iostreams filesystem)
-find_dependency(TIFF REQUIRED)
+find_dependency(OMECommon COMPONENTS Common XML)
+find_dependency(Boost 1.46 COMPONENTS boost iostreams filesystem)
+find_dependency(TIFF)
 
 include(${CMAKE_CURRENT_LIST_DIR}/OMEFilesInternal.cmake)
 


### PR DESCRIPTION
This is added implicitly by find_dependency.

See https://github.com/ome/ome-common-cpp/pull/51 for context.