### PR TITLE
Update docs links to use new URLs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,10 +1,10 @@
 # Contributing to Bio-Formats
 
 Guidance for contributing to OME projects in general can be found at
-http://www.openmicroscopy.org/site/support/contributing/
+https://docs.openmicroscopy.org/contributing/
 
 Developer documentation specifically for Bio-Formats is at
-http://www.openmicroscopy.org/site/support/bio-formats/developers/
+https://docs.openmicroscopy.org/latest/bio-formats/developers/
 
 The README file gives instructions for testing your code before opening a PR,
 please ensure you read these.
@@ -22,7 +22,7 @@ please ensure you read these.
 * We may need you to submit some test data
   [via our QA system](http://qa.openmicroscopy.org.uk/qa/upload/). If the
   files are particularly large (> ~2 GB), contact the
-  [mailing list](http://www.openmicroscopy.org/site/community/mailing-lists)
+  [mailing list](https://www.openmicroscopy.org/support/)
   and we will get back to you with secure upload details.
 
 ## External Contributors
@@ -50,13 +50,13 @@ please ensure you read these.
 ## Contributing to Bio-Formats Documentation
 
 The documentation hosted at
-http://www.openmicroscopy.org/site/support/bio-formats/ is built from the
+https://docs.openmicroscopy.org/latest/bio-formats/ is built from the
 `/docs/sphinx/` directory. Contributions are welcome but please follow the
 style guidance from the
 [OME Documentation Repository README](https://github.com/openmicroscopy/ome-documentation/blob/develop/README.rst#conventions-used).
 
 Documentation for new supported formats is auto-generated so it is best to
-contact the [mailing list](http://www.openmicroscopy.org/site/community/mailing-lists)
+contact the [mailing list](https://www.openmicroscopy.org/support/)
 before embarking on such a change, or submit your new reader code and let one
 of the main OME team deal with the documentation for you.
 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ image file formats.
 Links
 -----
 
-- [Overview of all components](http://www.openmicroscopy.org/site/support/ome-files-cpp/)
-- [Documentation](http://www.openmicroscopy.org/site/support/ome-files-cpp/ome-files/manual/html/index.html)
-- [Tutorial](http://www.openmicroscopy.org/site/support/ome-files-cpp/ome-files/manual/html/tutorial.html)
-- [API reference](http://www.openmicroscopy.org/site/support/ome-files-cpp/ome-files/api/html/namespaces.html)
+- [Overview of all components](https://docs.openmicroscopy.org/latest/ome-files-cpp/)
+- [Documentation](https://docs.openmicroscopy.org/latest/ome-files-cpp/ome-files/manual/html/index.html)
+- [Tutorial](https://docs.openmicroscopy.org/latest/ome-files-cpp/ome-files/manual/html/tutorial.html)
+- [API reference](https://docs.openmicroscopy.org/latest/ome-files-cpp/ome-files/api/html/namespaces.html)
 - [Performance testing](https://github.com/openmicroscopy/ome-files-performance)
 
 Purpose
@@ -18,7 +18,7 @@ Purpose
 OME Files' primary purpose is to convert proprietary microscopy data
 into an open standard called the OME data model, particularly into the
 OME-TIFF file format. See the [statement of
-purpose](http://www.openmicroscopy.org/site/support/bio-formats/about/index.html)
+purpose](https://docs.openmicroscopy.org/latest/bio-formats/about/index.html)
 for a thorough explanation and rationale.  OME Files provides support
 for reading and writing files using the OME-TIFF file format and for
 the OME metadata model which is the basis for the file format.
@@ -33,7 +33,7 @@ For users
 ---------
 
 [Many software
-packages](http://www.openmicroscopy.org/site/support/bio-formats/users/index.html)
+packages](https://docs.openmicroscopy.org/latest/bio-formats/users/index.html)
 use Bio-Formats to read and write open microscopy formats such as
 OME-TIFF in Java programs.  OME Files provides equivalent
 functionality for C++ programs.
@@ -48,8 +48,7 @@ You can use OME Files C++ to easily support OME-TIFF in your software.
 More information
 ----------------
 
-For more information, see the [documentation]
-(http://www.openmicroscopy.org/site/support/ome-files-cpp/).
+For more information, see the [documentation](https://docs.openmicroscopy.org/latest/ome-files-cpp/).
 
 
 Pull request testing


### PR DESCRIPTION
See https://trello.com/c/oxWdJSKf/610-clean-up-remaining-links-to-site-support-old-docs-urls