### PR TITLE
Boost 1.67 fixes

### DIFF
--- a/lib/ome/files/CMakeLists.txt
+++ b/lib/ome/files/CMakeLists.txt
@@ -182,6 +182,11 @@ target_link_libraries(ome-files
                       Boost::filesystem
                       TIFF::TIFF)
 
+if(WIN32)
+  # Boost UUID (≥ 1.67) requires bcrypt on Windows
+  target_link_libraries(ome-files bcrypt)
+endif()
+
 set_target_properties(ome-files PROPERTIES VERSION ${ome-files_VERSION})
 
 add_library(OME::Files ALIAS ome-files)

--- a/lib/ome/files/out/OMETIFFWriter.cpp
+++ b/lib/ome/files/out/OMETIFFWriter.cpp
@@ -37,6 +37,10 @@
 
 #include <cassert>
 
+// Include first due to side effect of MPL vector limit setting which can change the default
+// and break multi_index with Boost 1.67
+#include <ome/xml/meta/Convert.h>
+
 #include <boost/filesystem/path.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/format.hpp>
@@ -60,8 +64,6 @@
 
 #include <ome/common/endian.h>
 #include <ome/common/filesystem.h>
-
-#include <ome/xml/meta/Convert.h>
 
 #include <tiffio.h>
 


### PR DESCRIPTION
Reorder of headers, similar to steps already taken in the past in other source files, e.g. `test/ome-files/metadatamap.cpp` but the other way around (at the beginning rather than the end, so the limits aren't yet set).

Testing: Check builds are green, the Windows builds in particular since VS2015 was the compiler previously failing without this tweak.