### PR TITLE
tiff: Allow flushing of tiles in any order

### DIFF
--- a/lib/ome/files/tiff/IFD.cpp
+++ b/lib/ome/files/tiff/IFD.cpp
@@ -340,49 +340,45 @@ namespace
       tiles(tiles)
     {}
 
-    // Flush covered tiles.
+    // Flush covered tile.
     void
-    flush()
+    flush(tstrile_t tile)
     {
       std::shared_ptr<::ome::files::tiff::TIFF>& tiff(ifd.getTIFF());
       ::TIFF *tiffraw = reinterpret_cast<::TIFF *>(tiff->getWrapped());
       TileType type = tileinfo.tileType();
       PlaneRegion rimage(0, 0, ifd.getImageWidth(), ifd.getImageHeight());
-      tstrile_t tile = static_cast<tstrile_t>(ifd.getCurrentTile());
 
       Sentry sentry;
-      while(tile < tileinfo.tileCount())
+
+      dimension_size_type tile_subchannel = tileinfo.tileSample(tile);
+
+      PlaneRegion validarea = tileinfo.tileRegion(tile) & rimage;
+      if (!validarea.area())
+        return;
+
+      if (!tilecoverage.at(tile_subchannel).covered(validarea))
+        return;
+
+      assert(tilecache.find(tile));
+      TileBuffer& tilebuf = *tilecache.find(tile);
+      if (type == TILE)
         {
-          dimension_size_type tile_subchannel = tileinfo.tileSample(tile);
-
-          PlaneRegion validarea = tileinfo.tileRegion(tile) & rimage;
-          if (!validarea.area())
-            break;
-
-          if (!tilecoverage.at(tile_subchannel).covered(validarea))
-            break;
-
-          assert(tilecache.find(tile));
-          TileBuffer& tilebuf = *tilecache.find(tile);
-          if (type == TILE)
-            {
-              tsize_t byteswritten = TIFFWriteEncodedTile(tiffraw, tile, tilebuf.data(), static_cast<tsize_t>(tilebuf.size()));
-              if (byteswritten < 0)
-                sentry.error("Failed to write encoded tile");
-              else if (static_cast<dimension_size_type>(byteswritten) != tilebuf.size())
-                sentry.error("Failed to write encoded tile fully");
-            }
-          else
-            {
-              tsize_t byteswritten = TIFFWriteEncodedStrip(tiffraw, tile, tilebuf.data(), static_cast<tsize_t>(tilebuf.size()));
-              if (byteswritten < 0)
-                sentry.error("Failed to write encoded strip");
-              else if (static_cast<dimension_size_type>(byteswritten) != tilebuf.size())
-                sentry.error("Failed to write encoded strip fully");
-            }
-          tilecache.erase(tile);
-          ifd.setCurrentTile(++tile);
+          tsize_t byteswritten = TIFFWriteEncodedTile(tiffraw, tile, tilebuf.data(), static_cast<tsize_t>(tilebuf.size()));
+          if (byteswritten < 0)
+            sentry.error("Failed to write encoded tile");
+          else if (static_cast<dimension_size_type>(byteswritten) != tilebuf.size())
+            sentry.error("Failed to write encoded tile fully");
         }
+      else
+        {
+          tsize_t byteswritten = TIFFWriteEncodedStrip(tiffraw, tile, tilebuf.data(), static_cast<tsize_t>(tilebuf.size()));
+          if (byteswritten < 0)
+            sentry.error("Failed to write encoded strip");
+          else if (static_cast<dimension_size_type>(byteswritten) != tilebuf.size())
+            sentry.error("Failed to write encoded strip fully");
+        }
+      tilecache.erase(tile);
     }
 
     template<typename T>
@@ -525,10 +521,11 @@ namespace
 
           transfer(buffer, srcidx, tilebuf, rfull, rclip, copysamples);
           tilecoverage.at(dest_subchannel).insert(rclip);
+
+          // Flush tile if covered.
+          flush(tile);
         }
 
-      // Flush covered tiles
-      flush();
     }
   };
 
@@ -602,8 +599,6 @@ namespace ome
         boost::optional<PhotometricInterpretation> photometric;
         /// Compression scheme.
         boost::optional<Compression> compression;
-        /// Current tile (for writing).
-        tstrile_t ctile;
 
         /**
          * Constructor.
@@ -623,8 +618,7 @@ namespace ome
           tileheight(),
           pixeltype(),
           samples(),
-          planarconfig(),
-          ctile(0)
+          planarconfig()
         {
         }
 
@@ -829,18 +823,6 @@ namespace ome
       IFD::setTileType(TileType type)
       {
         impl->tiletype = type;
-      }
-
-      dimension_size_type
-      IFD::getCurrentTile() const
-      {
-        return impl->ctile;
-      }
-
-      void
-      IFD::setCurrentTile(dimension_size_type tile)
-      {
-        impl->ctile = static_cast<tstrile_t>(tile);
       }
 
       TileInfo

--- a/lib/ome/files/tiff/IFD.h
+++ b/lib/ome/files/tiff/IFD.h
@@ -247,30 +247,6 @@ namespace ome
         setTileType(TileType type);
 
         /**
-         * Get the current tile being written.
-         *
-         * This is the tile currently being modified pending flush.
-         *
-         * @returns the current tile.
-         */
-        dimension_size_type
-        getCurrentTile() const;
-
-        /**
-         * Set the current tile being written.
-         *
-         * This is the tile currently being modified pending flush.
-         *
-         * @note This should not be set by hand; it will be updated by
-         * the code writing out tile data called internally by
-         * writeImage().
-         *
-         * @param tile the current tile.
-         */
-        void
-        setCurrentTile(dimension_size_type tile);
-
-        /**
          * Get tiling metadata.
          *
          * @returns the TileInfo metadata for this IFD.


### PR DESCRIPTION
Closes: https://github.com/ome/ome-files-cpp/issues/97

Instead of flushing the tiles strictly in index order, flush them as soon as they are covered.  This reduces the size of the tile cache, and spreads out disc I/O, if the tiles are written in a different order.

There is no change in usage.  The API continues to allow saveBytes to be called in any order and with any size of region, which may or may not overlap with the tile size.  The only change is when tiles are flushed from the tile cache, which is now earlier than before for certain usage patterns.  All other aspects are unchanged.

Testing: Writing in different orders, including random order, with and without saveBytes regions overlapping tile boundaries, is already handled by the unit tests (`tiff`), including validation of the pixel data.  Check that all builds remain green.