### PR TITLE
tiff: Support YCbCr and LUV image reading

### DIFF
--- a/lib/ome/files/tiff/TileInfo.cpp
+++ b/lib/ome/files/tiff/TileInfo.cpp
@@ -7,6 +7,7 @@
  *   - University of Dundee
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
+ * Copyright © 2018 Quantitative Imaging Systems, LLC
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -221,6 +222,12 @@ namespace ome
       TileInfo::bufferSize() const
       {
         return impl->buffersize;
+      }
+
+      dimension_size_type
+      TileInfo::bufferSizeRGBA() const
+      {
+        return 4U * impl->tilewidth * impl->tileheight;
       }
 
       dimension_size_type

--- a/lib/ome/files/tiff/TileInfo.h
+++ b/lib/ome/files/tiff/TileInfo.h
@@ -7,6 +7,7 @@
  *   - University of Dundee
  *   - Board of Regents of the University of Wisconsin-Madison
  *   - Glencoe Software, Inc.
+ * Copyright © 2018 Quantitative Imaging Systems, LLC
  * %%
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions are met:
@@ -130,6 +131,18 @@ namespace ome
          */
         dimension_size_type
         bufferSize() const;
+
+        /**
+         * Get the buffer size needed to contain a single tile in RGBA format.
+         *
+         * For @c TIFFReadRGBATile and @c TIFFReadRGBAStrip and
+         * related functions.  The buffer is unsigned 32-bit data
+         * comprised of unsigned 8-bit RGBA samples.
+         *
+         * @returns the buffer size.
+         */
+        dimension_size_type
+        bufferSizeRGBA() const;
 
         /**
          * Get the tile index covering the given coordinates.


### PR DESCRIPTION
The OME-TIFF pyramid samples created from Leica SCN files use JPEG compression in a YCbCr colourspace.  We aren't doing RGB conversion, and return the Y, Cb and Cr components as subchannel samples.  This PR adds support for this conversion.

This is separated from the OME-TIFF sub-resolution reading PR, because it's unrelated to pyramids, and is useful for all images using JPEG compression, and other non-RGB colourspaces.  Only UINT8 images are supported for this type of colourspace conversion, due to libtiff using an 8-bit RGBA output buffer for this type of automatic conversion.

Testing:

- See PR https://github.com/ome/ome-qtwidgets/pull/42

Note: I'm seeing some odd off-by-one errors on tile-boundaries in non-zero tile column indexes and a black band at the end of the bottom tile.  There's something stupid in the pixel transfer from the RGBA tile buffers which will need adjusting before this can be merged.

Sub-resolution level 1 of `Leica-1-subifds.ome.tiff`:
![screenshot_20180728_004814](https://user-images.githubusercontent.com/9640520/43350545-1ab6f562-9200-11e8-8a9d-0b76fac9a457.png)

/cc @dsudar